### PR TITLE
chore: 🤖 Makes rich-text-from-markdown public npm package

### DIFF
--- a/packages/rich-text-from-markdown/package.json
+++ b/packages/rich-text-from-markdown/package.json
@@ -22,6 +22,9 @@
     "type": "git",
     "url": "git+https://github.com/contentful/rich-text.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "tsc --module commonjs && rollup -c rollup.config.js",


### PR DESCRIPTION
PR makes `rich-text-from-markdown` a public npm repo.