### PR TITLE
docs: ✏️ Update README

### DIFF
--- a/packages/rich-text-from-markdown/README.md
+++ b/packages/rich-text-from-markdown/README.md
@@ -42,7 +42,7 @@ of that node.
 #### Example: 
 
 ```js
-const richTextFromMarkdown = require('@contentful/rich-text-from-markdown');
+const { richTextFromMarkdown } = require('@contentful/rich-text-from-markdown');
 
 // define your own type for unsupported nodes like asset
 const document = richTextFromMarkdown(


### PR DESCRIPTION
Example should show `richTextFromMarkdown` being imported as a named function, not a default import.