### PR TITLE
fix: 🐛 handle case of missing rootNode / rootNode.content

### DIFF
--- a/packages/rich-text-plain-text-renderer/src/index.ts
+++ b/packages/rich-text-plain-text-renderer/src/index.ts
@@ -10,6 +10,16 @@ export function documentToPlainTextString(
   rootNode: Block | Inline,
   blockDivisor: string = ' ',
 ): string {
+  if (!rootNode || !rootNode.content) {
+    /**
+     * Handles edge cases, such as when the value is not set in the CMA or the
+     * field has not been properly validated, e.g. because of a user extension.
+     * Note that we are nevertheless strictly type-casting `rootNode` as
+     * Block | Inline. Valid rich text documents (and their branch block nodes)
+     * should never lack a Node[] `content` property.
+     */
+    return '';
+  }
   /**
    * Algorithm notes: We only want to apply spacing when a node is part of a
    * sequence. This is tricky because nodes can often be deeply nested within


### PR DESCRIPTION
## Purpose

We are receiving Sentry errors for the `rich-text-plain-text-renderer` that have to do with malformed rich text document values:

- [`Cannot read property 'reduce' of undefined`](https://sentry.io/contentful/content-management-api-production/issues/757767415/) (missing `rootNode`)
- [`Cannot read property 'content' of null`](https://sentry.io/contentful/content-management-api-production/issues/759404964/) (missing `rootNode.content`)

**NB:** `rootNode` can refer to _either_ the root node of the rich text document as a whole, _or_ a branch `Block | Inline` node, since we use this function to DFS the document. So the problem here can involve invalid composition at _any_ level of the document, not just `richTextPlainTextRenderer()` being called on something undefined.

We should expect to see these kinds of errors drop as we introduce more document-level validation in the CMA and Webapp. Still, we should provide some kind of default value here rather than mysteriously erroring out; ideally malformed data would be caught and specified elsewhere.

## Approach

Returns `''` early when `rootNode` or `rootNode.content` is falsy.