### PR TITLE
Return all entity links when no linkType is provided

### DIFF
--- a/packages/rich-text-from-markdown/src/index.ts
+++ b/packages/rich-text-from-markdown/src/index.ts
@@ -22,8 +22,8 @@ export interface MarkdownNode {
   depth: string;
   type: string;
   ordered: Boolean;
-  children: Array<MarkdownNode>;
-  content: Array<MarkdownNode>;
+  children: MarkdownNode[];
+  content: MarkdownNode[];
   value: string;
 }
 

--- a/packages/rich-text-from-markdown/src/types/index.ts
+++ b/packages/rich-text-from-markdown/src/types/index.ts
@@ -3,8 +3,8 @@ declare module 'unified' {
     depth: string;
     type: string;
     ordered: Boolean;
-    children: Array<MarkdownNode>;
-    content: Array<MarkdownNode>;
+    children: MarkdownNode[];
+    content: MarkdownNode[];
     value: string;
   }
 

--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -42,24 +42,45 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    it('works with entry links', () => {
-      expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
-        {
-          linkType: 'Entry',
-          type: 'Link',
-          id: 'foo',
-        },
-      ]);
+    describe('when the link type is "Entry"', () => {
+      it('returns the matching link objects', () => {
+        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
 
-    it('works with asset links', () => {
-      expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
-        {
-          linkType: 'Asset',
-          type: 'Link',
-          id: 'bar',
-        },
-      ]);
+    describe('when the link type is "Asset"', () => {
+      it('returns the matching link objects', () => {
+        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+        ]);
+      });
+    });
+
+    describe('when no link type is provided', () => {
+      it('returns all entity link objects', () => {
+        expect(getRichTextEntityLinks(document)).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
   });
 
@@ -159,34 +180,65 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    it('works with entry links', () => {
-      expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
-        {
-          linkType: 'Entry',
-          type: 'Link',
-          id: 'baz',
-        },
-        {
-          linkType: 'Entry',
-          type: 'Link',
-          id: 'foo',
-        },
-      ]);
+    describe('when the link type is "Entry"', () => {
+      it('returns all unique matching links', () => {
+        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'baz',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
 
-    it('works with asset links', () => {
-      expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
-        {
-          linkType: 'Asset',
-          type: 'Link',
-          id: 'bar',
-        },
-        {
-          linkType: 'Asset',
-          type: 'Link',
-          id: 'quux',
-        },
-      ]);
+    describe('when the link type is "Asset"', () => {
+      it('returns all unique matching links', () => {
+        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'quux',
+          },
+        ]);
+      });
+    });
+
+    describe('when no link type is provided', () => {
+      it('returns all entity link objects', () => {
+        expect(getRichTextEntityLinks(document)).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'baz',
+          },
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'quux',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
   });
 
@@ -294,24 +346,45 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    it('ignores redundant entry links', () => {
-      expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
-        {
-          linkType: 'Entry',
-          type: 'Link',
-          id: 'foo',
-        },
-      ]);
+    describe('when the link type is "Entry"', () => {
+      it('ignores redundant entry links', () => {
+        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
 
-    it('ignores redundant asset links', () => {
-      expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
-        {
-          linkType: 'Asset',
-          type: 'Link',
-          id: 'bar',
-        },
-      ]);
+    describe('when the link type is "Asset"', () => {
+      it('ignores redundant asset links', () => {
+        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+        ]);
+      });
+    });
+
+    describe('when no link type is provided', () => {
+      it('ignores all redundant links', () => {
+        expect(getRichTextEntityLinks(document)).toEqual([
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'bar',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'foo',
+          },
+        ]);
+      });
     });
   });
 });

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -27,15 +27,17 @@ class Cache {
 }
 
 /**
- * Given a rich text document and an entity type, returns all unique matching
- * entity links.
+ * Given a rich text document and an (optional) entity type, returns all unique
+ * matching entity links.
+ *
+ * If there is no linkType provided, returns all unique entity links.
  */
-export function getRichTextEntityLinks(document: Document, linkType: EntityType): EntityLink[] {
+export function getRichTextEntityLinks(document: Document, linkType?: EntityType): EntityLink[] {
   const links: EntityLink[] = [];
   const linkCache: LinkCache = new Cache();
 
   for (const node of document.content) {
-    addLinksFromRichTextNode(links, node, linkType, linkCache);
+    addLinksFromRichTextNode(links, node, linkCache, linkType);
   }
 
   return links;
@@ -44,8 +46,8 @@ export function getRichTextEntityLinks(document: Document, linkType: EntityType)
 function addLinksFromRichTextNode(
   links: EntityLink[],
   node: Node,
-  linkType: EntityType,
   linkCache: LinkCache,
+  linkType?: EntityType,
 ): EntityLink[] {
   const toCrawl: Node[] = [node];
 
@@ -65,8 +67,14 @@ function addLinksFromRichTextNode(
   return links;
 }
 
-function isMatchingLinkObject(data: NodeData, linkType: EntityType): Boolean {
+function isMatchingLinkObject(data: NodeData, linkType?: EntityType): Boolean {
   const sys = data && (data.target as SysObject) && (data.target.sys as EntityLink);
-
-  return sys && typeof sys.id === 'string' && sys.type === 'Link' && sys.linkType === linkType;
+  const isLinkObject = sys && typeof sys.id === 'string' && sys.type === 'Link';
+  if (!isLinkObject) {
+    return false;
+  }
+  if (linkType) {
+    return sys.linkType === linkType;
+  }
+  return sys.linkType === 'Entry' || sys.linkType === 'Asset';
 }

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -129,7 +129,7 @@ export interface EntryLinkInline extends Inline {
    *
    * @maxItems 0
    */
-  content: Array<Text>;
+  content: Text[];
 }
 
 export interface Hyperlink extends Inline {
@@ -138,7 +138,7 @@ export interface Hyperlink extends Inline {
     uri: string;
     title: string;
   };
-  content: Array<Text>;
+  content: Text[];
 }
 
 export interface AssetHyperlink extends Inline {
@@ -147,7 +147,7 @@ export interface AssetHyperlink extends Inline {
     target: Link<'Asset'>;
     title: string;
   };
-  content: Array<Text>;
+  content: Text[];
 }
 
 export interface EntryHyperlink extends Inline {
@@ -156,5 +156,5 @@ export interface EntryHyperlink extends Inline {
     target: Link<'Entry'>;
     title: string;
   };
-  content: Array<Text>;
+  content: Text[];
 }


### PR DESCRIPTION
## Summary

- Updates `rich-text-links`'s `getRichTextEntityLinks()` to return _all_ entity links when no `linkType` is provided.
  - Previously we required the second `linkType` parameter. But in some cases (e.g. when enforcing publication constraints on link count), we really only care how many entity links _total_ appear in a rich text field, regardless of whether they qualify as "Entry" or "Asset" links.
- Ships a small stylistic change to prefer condensed single-type array type declaration syntax where possible.
  - e.g. `Array<Node>` -> `Node[]`

## Dependencies & References

Will be pulled in as part of [AUTH-716](https://contentful.atlassian.net/browse/AUTH-716).