### PR TITLE
fix: 🐛 Removes obsolete field `title` from Hyperlinks

### DIFF
--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -136,7 +136,6 @@ export interface Hyperlink extends Inline {
   nodeType: INLINES.HYPERLINK;
   data: {
     uri: string;
-    title: string;
   };
   content: Text[];
 }
@@ -145,7 +144,6 @@ export interface AssetHyperlink extends Inline {
   nodeType: INLINES.ASSET_HYPERLINK;
   data: {
     target: Link<'Asset'>;
-    title: string;
   };
   content: Text[];
 }
@@ -154,7 +152,6 @@ export interface EntryHyperlink extends Inline {
   nodeType: INLINES.ENTRY_HYPERLINK;
   data: {
     target: Link<'Entry'>;
-    title: string;
   };
   content: Text[];
 }

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -20,13 +20,9 @@ Object {
             "target": Object {
               "$ref": "#/definitions/Link<\\"Asset\\">",
             },
-            "title": Object {
-              "type": "string",
-            },
           },
           "required": Array [
             "target",
-            "title",
           ],
           "type": "object",
         },
@@ -1003,13 +999,9 @@ Object {
             "target": Object {
               "$ref": "#/definitions/Link<\\"Entry\\">",
             },
-            "title": Object {
-              "type": "string",
-            },
           },
           "required": Array [
             "target",
-            "title",
           ],
           "type": "object",
         },
@@ -2033,15 +2025,11 @@ Object {
         "data": Object {
           "additionalProperties": false,
           "properties": Object {
-            "title": Object {
-              "type": "string",
-            },
             "uri": Object {
               "type": "string",
             },
           },
           "required": Array [
-            "title",
             "uri",
           ],
           "type": "object",

--- a/packages/rich-text-types/src/schemas/generated/asset-hyperlink.json
+++ b/packages/rich-text-types/src/schemas/generated/asset-hyperlink.json
@@ -15,15 +15,11 @@
           "properties": {
             "target": {
               "$ref": "#/definitions/Link<\"Asset\">"
-            },
-            "title": {
-              "type": "string"
             }
           },
           "additionalProperties": false,
           "required": [
-            "target",
-            "title"
+            "target"
           ]
         },
         "content": {

--- a/packages/rich-text-types/src/schemas/generated/entry-hyperlink.json
+++ b/packages/rich-text-types/src/schemas/generated/entry-hyperlink.json
@@ -15,15 +15,11 @@
           "properties": {
             "target": {
               "$ref": "#/definitions/Link<\"Entry\">"
-            },
-            "title": {
-              "type": "string"
             }
           },
           "additionalProperties": false,
           "required": [
-            "target",
-            "title"
+            "target"
           ]
         },
         "content": {

--- a/packages/rich-text-types/src/schemas/generated/hyperlink.json
+++ b/packages/rich-text-types/src/schemas/generated/hyperlink.json
@@ -15,14 +15,10 @@
           "properties": {
             "uri": {
               "type": "string"
-            },
-            "title": {
-              "type": "string"
             }
           },
           "additionalProperties": false,
           "required": [
-            "title",
             "uri"
           ]
         },


### PR DESCRIPTION
PR removes currently unused field `title` from Hyperlinks definition