### PR TITLE
Improve rich-text-links and add benchmarking

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,26 @@ repository as a whole.
 We use [Jest](https://jestjs.io/) for unit tests. See **Useful npm scripts**
 above for some relevant npm commands.
 
+### Benchmarks
+
+Some packages may contain benchmark scripts to prevent against performance
+regressions. We use [Benchmark](https://benchmarkjs.com/) for these. Benchmarked
+files should be written in TypeScript with the same code style and formatting
+conventions as the rest of the codebase - we use `ts-node` (anchored to the
+Node version in `./node-version`) to evaluate these.
+
+Benchmarks are stored in the `bin/benchmark` folder of each relevant package.
+To run all benchmarks for a particular package, e.g. `rich-text-links`, you
+can use a Lerna command scoped to that package:
+
+```sh
+lerna exec "npm run benchmark" --scope=@contentful/rich-text-links
+```
+
+Before submitting a pull request for a package with benchmarked code paths,
+please make sure that your changes do not negatively impact performance.
+(Of course, PRs _improving_ performance are always welcome! :smile:)
+
 ## Publishing
 
 We use [Lerna](https://github.com/lerna/lerna) to:

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "lerna run build",
     "commit": "git-cz",
     "clean": "lerna exec 'rm -rf node_modules/ dist/ && npm prune' && rm -rf node_modules/ && npm prune",
-    "lint": "tslint -t codeFrame 'packages/**/src/*.ts'",
+    "lint": "tslint -t codeFrame 'packages/**/@(src|bin)/*.ts'",
     "postinstall": "lerna bootstrap --hoist --progress --no-ci",
     "prebuild": "lerna run prebuild",
     "prepublishOnly": "npm i && npm run build && npm run lint && npm run test",

--- a/packages/rich-text-links/README.md
+++ b/packages/rich-text-links/README.md
@@ -59,9 +59,16 @@ const document = {
   ],
 };
 
-getRichTextEntityLinks(document, 'Entry');
-// -> [{ linkType: 'Entry', type: 'Link', id: 'yXmVKmaDBm8tRfQMwA0e' }]
-
-getRichTextEntityLinks(document, 'Asset');
-// -> [{ linkType: 'Asset', type: 'Link', id: 'jNhaW0aSc6Hu74SHVMtq' }]
+getRichTextEntityLinks(document);
+/**
+ * ->
+ * {
+ *   Entry: [
+ *     { linkType: 'Entry', type: 'Link', id: 'yXmVKmaDBm8tRfQMwA0e' }
+ *   ],
+ *   Asset: [
+ *     { linkType: 'Asset', type: 'Link', id: 'jNhaW0aSc6Hu74SHVMtq' }
+ *   ]
+ * }
+ */
 ```

--- a/packages/rich-text-links/bin/benchmark/get-rich-text-links.ts
+++ b/packages/rich-text-links/bin/benchmark/get-rich-text-links.ts
@@ -1,0 +1,187 @@
+import { Document, BLOCKS, INLINES } from '@contentful/rich-text-types';
+import { getRichTextEntityLinks } from '../../src/index';
+
+const richTextField: Document = {
+  nodeType: BLOCKS.DOCUMENT,
+  data: {},
+  content: [
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: '',
+        },
+        {
+          nodeType: INLINES.ASSET_HYPERLINK,
+          data: {
+            target: {
+              sys: {
+                id: 'cover',
+                type: 'Link',
+                linkType: 'Asset',
+              },
+            },
+          },
+          content: [
+            {
+              nodeType: 'text',
+              data: {},
+              marks: [],
+              value: 'Cover',
+            },
+          ],
+        },
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: '',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: 'This book by author ',
+        },
+        {
+          nodeType: INLINES.EMBEDDED_ENTRY,
+          data: {
+            target: {
+              sys: {
+                id: 'author',
+                type: 'Link',
+                linkType: 'Entry',
+              },
+            },
+          },
+          content: [
+            {
+              nodeType: 'text',
+              data: {},
+              marks: [],
+              value: '',
+            },
+          ],
+        },
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: 'was an instant classic.',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: 'The first chapter is free to read: ',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.EMBEDDED_ENTRY,
+      data: {
+        target: {
+          sys: {
+            id: 'chapter-1',
+            type: 'Link',
+            linkType: 'Entry',
+          },
+        },
+      },
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: '',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: '',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.PARAGRAPH,
+      data: {},
+      content: [
+        {
+          nodeType: 'text',
+          data: {},
+          marks: [],
+          value: '',
+        },
+      ],
+    },
+    {
+      nodeType: BLOCKS.UL_LIST,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.LIST_ITEM,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_ENTRY,
+              data: {
+                target: {
+                  sys: {
+                    id: 'chapter-2',
+                    type: 'Link',
+                    linkType: 'Entry',
+                  },
+                },
+              },
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: '',
+                },
+              ],
+            },
+            {
+              nodeType: BLOCKS.PARAGRAPH,
+              data: {},
+              content: [
+                {
+                  nodeType: 'text',
+                  data: {},
+                  marks: [],
+                  value: '',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export const getRichTextLinks = () => getRichTextEntityLinks(richTextField);

--- a/packages/rich-text-links/bin/benchmark/index.ts
+++ b/packages/rich-text-links/bin/benchmark/index.ts
@@ -1,0 +1,38 @@
+import { readdir } from 'fs';
+import Benchmark from 'benchmark';
+
+const suite = new Benchmark.Suite();
+
+/**
+ * This is a generalized onComplete callback for each of the Benchmark objects.
+ * `event.target` returns the complete Benchmark object itself, while in its
+ * stringified form, we get a nice outputtable summary of the benchmark's
+ * perf data (appx ops/sec, # runs sampled).
+ */
+const onComplete = (event: { target: object }): void => {
+  console.log(event.target.toString());
+};
+
+readdir(__dirname, (err, files) => {
+  if (err) {
+    throw err;
+  }
+
+  const benchmarks: Array<[string, Function]> = Object.entries(
+    files
+      .filter((name) => name !== 'index.ts')
+      .map((name): { [key: string]: Function } => require(`./${name}`))
+      .reduce((allBenchmarks, fileBenchmarks) => Object.assign(
+        allBenchmarks,
+        fileBenchmarks
+      ), {})
+  );
+
+  for (const [name, benchmark] of benchmarks) {
+    suite.add(name, benchmark, { onComplete });
+  }
+
+  suite
+    .on('complete', () => console.log('\n✅ Completed all benchmarks'))
+    .run({ async: true });
+});

--- a/packages/rich-text-links/bin/tsconfig.json
+++ b/packages/rich-text-links/bin/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "target": "es2017"
+  }
+}

--- a/packages/rich-text-links/bin/tslint.json
+++ b/packages/rich-text-links/bin/tslint.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../../tslint.json",
+  "rules": {
+    "no-console": false
+  }
+}

--- a/packages/rich-text-links/package-lock.json
+++ b/packages/rich-text-links/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/rich-text-links",
-  "version": "10.0.5",
+  "version": "11.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -33,9 +33,15 @@
       }
     },
     "@contentful/rich-text-types": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-10.0.1.tgz",
-      "integrity": "sha512-1QJ2pqwt7BZuhjg/+VHAbZr+v1bazqt0YEuJQwcNYpkhS5C0N+MKkZ/qC2rO/BVSu2kc0u8lQlGnyRhcl8B6DA=="
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-11.0.0.tgz",
+      "integrity": "sha512-jPQUDCHqFowFg0OfXK2olXTr9eWF7g0iPbX6czymeXuejMbdqToBFjYVX6Ab2bSGKQuIVKO0bnq/HlzQW7XGCg=="
+    },
+    "@types/benchmark": {
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
+      "integrity": "sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -833,6 +839,16 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "brace-expansion": {
@@ -3996,6 +4012,12 @@
         "find-up": "^2.1.0"
       }
     },
+    "platform": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.5.tgz",
+      "integrity": "sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==",
+      "dev": true
+    },
     "pn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
@@ -5308,6 +5330,46 @@
         }
       }
     },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.9",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+          "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
+          }
+        }
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -5717,6 +5779,12 @@
       "requires": {
         "camelcase": "^4.1.0"
       }
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+      "dev": true
     }
   }
 }

--- a/packages/rich-text-links/package.json
+++ b/packages/rich-text-links/package.json
@@ -18,14 +18,17 @@
     "access": "public"
   },
   "scripts": {
-    "prebuild": "rimraf dist",
+    "benchmark": "ts-node -O '{\"module\": \"commonjs\"}' bin/benchmark",
     "build": "tsc --module commonjs && rollup -c rollup.config.js",
+    "prebuild": "rimraf dist",
     "start": "tsc && rollup -c rollup.config.js -w"
   },
   "dependencies": {
     "@contentful/rich-text-types": "^11.0.0"
   },
   "devDependencies": {
+    "@types/benchmark": "^1.0.31",
+    "benchmark": "^2.1.4",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.66.6",
@@ -35,6 +38,7 @@
     "rollup-plugin-sourcemaps": "^0.4.2",
     "rollup-plugin-typescript2": "^0.17.2",
     "ts-jest": "^23.10.4",
+    "ts-node": "^7.0.1",
     "typescript": "^2.9.2"
   }
 }

--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -42,44 +42,22 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    describe('when the link type is "Entry"', () => {
-      it('returns the matching link objects', () => {
-        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+    it('returns all entity link objects', () => {
+      expect(getRichTextEntityLinks(document)).toEqual({
+        Entry: [
           {
             linkType: 'Entry',
             type: 'Link',
             id: 'foo',
           },
-        ]);
-      });
-    });
-
-    describe('when the link type is "Asset"', () => {
-      it('returns the matching link objects', () => {
-        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+        ],
+        Asset: [
           {
             linkType: 'Asset',
             type: 'Link',
             id: 'bar',
           },
-        ]);
-      });
-    });
-
-    describe('when no link type is provided', () => {
-      it('returns all entity link objects', () => {
-        expect(getRichTextEntityLinks(document)).toEqual([
-          {
-            linkType: 'Asset',
-            type: 'Link',
-            id: 'bar',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'foo',
-          },
-        ]);
+        ],
       });
     });
   });
@@ -180,9 +158,9 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    describe('when the link type is "Entry"', () => {
-      it('returns all unique matching links', () => {
-        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+    it('returns all entity link objects', () => {
+      expect(getRichTextEntityLinks(document)).toEqual({
+        Entry: [
           {
             linkType: 'Entry',
             type: 'Link',
@@ -193,13 +171,8 @@ describe('getRichTextEntityLinks', () => {
             type: 'Link',
             id: 'foo',
           },
-        ]);
-      });
-    });
-
-    describe('when the link type is "Asset"', () => {
-      it('returns all unique matching links', () => {
-        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+        ],
+        Asset: [
           {
             linkType: 'Asset',
             type: 'Link',
@@ -210,34 +183,7 @@ describe('getRichTextEntityLinks', () => {
             type: 'Link',
             id: 'quux',
           },
-        ]);
-      });
-    });
-
-    describe('when no link type is provided', () => {
-      it('returns all entity link objects', () => {
-        expect(getRichTextEntityLinks(document)).toEqual([
-          {
-            linkType: 'Asset',
-            type: 'Link',
-            id: 'bar',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'baz',
-          },
-          {
-            linkType: 'Asset',
-            type: 'Link',
-            id: 'quux',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'foo',
-          },
-        ]);
+        ],
       });
     });
   });
@@ -346,44 +292,22 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    describe('when the link type is "Entry"', () => {
-      it('ignores redundant entry links', () => {
-        expect(getRichTextEntityLinks(document, 'Entry')).toEqual([
+    it('ignores all redundant links', () => {
+      expect(getRichTextEntityLinks(document)).toEqual({
+        Entry: [
           {
             linkType: 'Entry',
             type: 'Link',
             id: 'foo',
           },
-        ]);
-      });
-    });
-
-    describe('when the link type is "Asset"', () => {
-      it('ignores redundant asset links', () => {
-        expect(getRichTextEntityLinks(document, 'Asset')).toEqual([
+        ],
+        Asset: [
           {
             linkType: 'Asset',
             type: 'Link',
             id: 'bar',
           },
-        ]);
-      });
-    });
-
-    describe('when no link type is provided', () => {
-      it('ignores all redundant links', () => {
-        expect(getRichTextEntityLinks(document)).toEqual([
-          {
-            linkType: 'Asset',
-            type: 'Link',
-            id: 'bar',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'foo',
-          },
-        ]);
+        ],
       });
     });
   });


### PR DESCRIPTION
## Summary

- Simplifies the return value of `getRichTextEntityLinks`, while adding a ~2x performance improvement.
  - when testing this as a `rollup`ed package in `@contentful/models` and running against the benchmark script in that repository, I consistently got ~500k ops/sec results vs the current perf of ~950k ops/sec.
  - we should expect an even greater perf increase in other back-end repos, which are not using the optimized `@contentful/models` algo.
  - **BREAKING CHANGE:** Produces an entirely new return value and obviates the `linkType` parameter (all entities are grouped and returned by default).
- Pulls in `getRichTextEntityLinks` benchmark from `@contentful/models`, adapts to TypeScript, and creates the basis for systematic benchmarking, including documentation in CONTRIBUTING.md.

## Purpose

### Motivation

I noticed that the implementation of `getRichTextEntityLinks` in `@contentful/models`, while originally duplicated from @TimBeyer 's refactor in `content_api`, is nevertheless faster due to the use of the `Set` class as a caching mechanism.

(We were using a subset of the `Set` API with the hand-rolled `LinkCache` class, but this is not optimized, so node clients like the CMA/CDA won't see any benefits from its usage).

Rather than using `Set` with the sys object IDs, I cache with a `Map` having signature `Map<id, sysObject>`, then return the `sysObject`. This is preferable because most clients of `getRichTextEntityLinks` require the full sys object to be returned. Running
```es6
val.map(sys => sys.id)
```
has a trivial impact on performance compared with reconstructing all-new sys-objects from `id`s.

As for the ~2x performance increase, I am pretty sure that's just from invoking `Array.from` on the cached entries/assets, rather than spreading them into a new array (like `[...entries]`) as we're doing in `@contentful/models` currently.

### Benchmarking

This PR assumes that

1. benchmarking for this module should live in the monorepo, and
2. we ought to establish a generalized flow for benchmarking _any_ of the packages in this repo, since they are all expected to be highly atomic, modular, and performance-sensitive.

See the updates in `CONTRIBUTING.md` for more details. The tl;dr is that contributors can now run
```sh
lerna exec "npm run benchmark" --scope=@contentful/rich-text-links
```
to run all `rich-text-links` benchmarks, and we should be able to simply duplicate the benchmark flow in other packages if we want to benchmark code paths elsewhere.