### PR TITLE
refactor: 💡 (nit) rename from richTextLinks to richTextEntityLinks

### DIFF
--- a/packages/rich-text-links/bin/benchmark/get-rich-text-entity-links.ts
+++ b/packages/rich-text-links/bin/benchmark/get-rich-text-entity-links.ts
@@ -1,5 +1,5 @@
 import { Document, BLOCKS, INLINES } from '@contentful/rich-text-types';
-import { getRichTextEntityLinks } from '../../src/index';
+import richTextLinks from '../../src/index';
 
 const richTextField: Document = {
   nodeType: BLOCKS.DOCUMENT,
@@ -184,4 +184,6 @@ const richTextField: Document = {
   ],
 };
 
-export const getRichTextLinks = () => getRichTextEntityLinks(richTextField);
+export const getRichTextEntityLinks = () => (
+  richTextLinks.getRichTextEntityLinks(richTextField)
+);


### PR DESCRIPTION
Corrects the nomenclature in the filename and benchmark title.

(no need for an immediate version bump or anything, just something that needed to be changed before we forget about it)