### PR TITLE
fix: 🐛 add es7-object-polyfill

### DIFF
--- a/packages/rich-text-types/package-lock.json
+++ b/packages/rich-text-types/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/rich-text-types",
-  "version": "10.0.1",
+  "version": "12.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/rich-text-types/package.json
+++ b/packages/rich-text-types/package.json
@@ -24,6 +24,7 @@
     "generate-json-schema": "ts-node -O '{\"module\": \"commonjs\"}' ./tools/jsonSchemaGen"
   },
   "devDependencies": {
+    "core-js": "^2.5.7",
     "faker": "^4.1.0",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",

--- a/packages/rich-text-types/src/index.ts
+++ b/packages/rich-text-types/src/index.ts
@@ -1,3 +1,6 @@
+import 'core-js/fn/object/values';
+import 'core-js/fn/array/includes';
+
 export { default as BLOCKS } from './blocks';
 export { default as INLINES } from './inlines';
 export { default as MARKS } from './marks';


### PR DESCRIPTION
## Summary

Polyfills Object.values, without which this module is incompatible with `@contentful/validation` in CI (maybe in other respects).

Also makes this a friendlier export for our friends using es5 without a polyfill in their Babel step.

## Approach

I simply scoped the polyfill to `@contentful/rich-text-types` (not the repo as a whole, or as a component of the rollup compilation step) since we should attempt to minimize the amount of compatibility cruft we're throwing into each module.

## Dependencies & References

Affects https://github.com/contentful/contentful-validation/pull/126, which pulls in a new major version of this dependency and consequently fails the CI step.