### PR TITLE
fix: handle hyperlinks

### DIFF
--- a/packages/rich-text-from-markdown/src/__test__/index.test.ts
+++ b/packages/rich-text-from-markdown/src/__test__/index.test.ts
@@ -1,4 +1,4 @@
-import { Text } from '@contentful/rich-text-types';
+import { Hyperlink, Text } from '@contentful/rich-text-types';
 import _ from 'lodash';
 import { richTextFromMarkdown } from '..';
 
@@ -68,5 +68,23 @@ describe('parses complex inline image markdown correctly', () => {
     expect(document.content[2].nodeType).toBe('image');
     expect(document.content[3].nodeType).toBe('paragraph');
     expect(fallback).toBeCalledTimes(2);
+  });
+});
+
+describe('links', () => {
+  test('should correctly convert a link', async () => {
+    const document = await richTextFromMarkdown('[This is a link](https://contentful.com)');
+    const node = document.content[0].content[0] as Hyperlink;
+
+    expect(node.nodeType).toBe('hyperlink');
+    expect(node.data.uri).toBe('https://contentful.com');
+  });
+
+  test('should correctly parse the text', async () => {
+    const document = await richTextFromMarkdown('[This is a link](https://contentful.com)');
+    const node = document.content[0].content[0] as Hyperlink;
+
+    expect(node.content[0].nodeType).toBe('text');
+    expect(node.content[0].value).toBe('This is a link');
   });
 });

--- a/packages/rich-text-from-markdown/src/index.ts
+++ b/packages/rich-text-from-markdown/src/index.ts
@@ -86,6 +86,10 @@ const isText = (nodeType: string) => {
   return nodeContainerTypes.get(nodeType) === 'text';
 };
 
+const isInline = (nodeType: string) => {
+  return nodeContainerTypes.get(nodeType) === 'inline';
+};
+
 const markdownNodeToRichTextNode = async (
   node: MarkdownNode,
   fallback: (mdNode: MarkdownNode) => Promise<Block>,
@@ -125,6 +129,13 @@ const markdownNodeToRichTextNode = async (
       value: nodeValue,
       marks: marks,
       data: {},
+    });
+  } else if (isInline(nodeType)) {
+    return Promise.resolve({
+      nodeType: nodeType,
+      value: nodeValue,
+      content: nodeContent,
+      data: nodeData,
     });
   }
   return fallback(node);


### PR DESCRIPTION
Currently, `rich-text-from-markdown` doesn't handle hyperlinks, because it ignores all `inline` types. This fixes that.

I'm not sure if everything I wrote is necessary — e.g., adding the `data: nodeData` key — but I was just trying to keep it consistent with the code above it. (I'm not super familiar with rich text and its AST.)