### PR TITLE
Nullable marks

### DIFF
--- a/packages/rich-text-html-renderer/src/__test__/documents/hyperlink.ts
+++ b/packages/rich-text-html-renderer/src/__test__/documents/hyperlink.ts
@@ -31,7 +31,7 @@ export default {
         {
           nodeType: 'text',
           value: ' text.',
-          marks: [],
+          marks: null,
           data: {},
         },
       ],

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -94,7 +94,7 @@ function nodeListToHtmlString(nodes: CommonNode[], { renderNode, renderMark }: O
 
 function nodeToHtmlString(node: CommonNode, { renderNode, renderMark }: Options): string {
   if (helpers.isText(node)) {
-    if (node.marks.length > 0) {
+    if (node.marks && node.marks.length > 0) {
       return node.marks.reduce((value: string, mark: Mark) => {
         if (!renderMark[mark.type]) {
           return value;


### PR DESCRIPTION
`marks` are not always just arrays, they are _nullable_ arrays. When `null` is encountered for a `marks` property, it will fail with `cannot read length of undefined`.

This PR checks for the existence of the `marks` property before it checks for it's length.