### PR TITLE
Add html escaping to html renderer

### DIFF
--- a/packages/rich-text-html-renderer/package-lock.json
+++ b/packages/rich-text-html-renderer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/rich-text-html-renderer",
-  "version": "8.0.2",
+  "version": "12.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -32,10 +32,11 @@
         }
       }
     },
-    "@contentful/rich-text-types": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-8.0.2.tgz",
-      "integrity": "sha512-pKgPT/rra8id5krLA2z/6UmkHTGeKAI/cFggqyvCjw34tHBx0nPzDaXhvI6SI0ESzATZFvdUI+PPoQ3lOWgNew=="
+    "@types/escape-html": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-0.0.20.tgz",
+      "integrity": "sha512-6dhZJLbA7aOwkYB2GDGdIqJ20wmHnkDzaxV9PJXe7O02I2dSFTERzRB6JrX6cWKaS+VqhhY7cQUMCbO5kloFUw==",
+      "dev": true
     },
     "@types/estree": {
       "version": "0.0.39",
@@ -1074,6 +1075,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",

--- a/packages/rich-text-html-renderer/package.json
+++ b/packages/rich-text-html-renderer/package.json
@@ -23,9 +23,11 @@
     "start": "tsc && rollup -c rollup.config.js -w"
   },
   "dependencies": {
-    "@contentful/rich-text-types": "^12.0.1"
+    "@contentful/rich-text-types": "^12.0.1",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
+    "@types/escape-html": "0.0.20",
     "jest": "^23.6.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.66.6",

--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -97,6 +97,54 @@ describe('documentToHtmlString', () => {
     expect(documentToHtmlString(document, options)).toEqual(expected);
   });
 
+  it('renders escaped html', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'foo & bar',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    const expected = '<p>foo &amp; bar</p>';
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
+  it('renders escaped html with marks', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'foo & bar',
+              marks: [{ type: MARKS.UNDERLINE }, { type: MARKS.BOLD }],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    const expected = '<p><b><u>foo &amp; bar</u></b></p>';
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
   it('does not render unrecognized marks', () => {
     const document: Document = invalidMarksDoc;
     const expected = '<p>Hello world!</p>';

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -1,3 +1,4 @@
+import escape from 'escape-html';
 import {
   Document,
   Mark,
@@ -94,16 +95,17 @@ function nodeListToHtmlString(nodes: CommonNode[], { renderNode, renderMark }: O
 
 function nodeToHtmlString(node: CommonNode, { renderNode, renderMark }: Options): string {
   if (helpers.isText(node)) {
+    const nodeValue = escape(node.value);
     if (node.marks.length > 0) {
       return node.marks.reduce((value: string, mark: Mark) => {
         if (!renderMark[mark.type]) {
           return value;
         }
         return renderMark[mark.type](value);
-      }, node.value);
+      }, nodeValue);
     }
 
-    return node.value;
+    return nodeValue;
   } else {
     const nextNode: Next = nodes => nodeListToHtmlString(nodes, { renderMark, renderNode });
     if (!node.nodeType || !renderNode[node.nodeType]) {


### PR DESCRIPTION
PR adds html escaping to the html renderer. The text value will be escaped before passing to the mark renderers.

Example

```js
documentToHtmlString({
  nodeType: BLOCKS.DOCUMENT,
  data: {},
  content: [
    {
      nodeType: BLOCKS.PARAGRAPH,
      data: {},
      content: [
        {
          nodeType: 'text',
          value: 'foo & bar',
          marks: [{ type: MARKS.UNDERLINE }, { type: MARKS.BOLD }],
          data: {}
        }
      ]
    }
  ]
});
```

Previous result:
```html
<p><b><u>foo & bar</u></b></p>
```

Current result:
```html
<p><b><u>foo &amp; bar</u></b></p>
```