### PR TITLE
node.marks is undefined for nodes of type hyperlink

### DIFF
--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -96,7 +96,7 @@ function nodeListToHtmlString(nodes: CommonNode[], { renderNode, renderMark }: O
 function nodeToHtmlString(node: CommonNode, { renderNode, renderMark }: Options): string {
   if (helpers.isText(node)) {
     const nodeValue = escape(node.value);
-    if (node.marks.length > 0) {
+    if (node.marks && node.marks.length > 0) {
       return node.marks.reduce((value: string, mark: Mark) => {
         if (!renderMark[mark.type]) {
           return value;


### PR DESCRIPTION
See issue below caused when Contentful doesn't return a marks node all the time... (see the node type hyperlink below)  Error is included after example.

```javascript
               {
                  "content": [
                    {
                      "marks": [],
                      "data": {
                        "uri": null
                      },
                      "value": "Standard sizes availableCut to length service",
                      "nodeType": "text",
                      "content": null
                    },
                    {
                      "marks": null,
                      "data": {
                        "uri": "https://www.monti-inc.com/materiallist"
                      },
                      "value": null,
                      "nodeType": "hyperlink",
                      "content": [
                        {
                          "value": "Click here to view Monti Inc's complete materials list.",
                          "nodeType": "text",
                          "content": null
                        }
                      ]
                    },
                    {
                      "marks": [],
                      "data": {
                        "uri": null
                      },
                      "value": "",
                      "nodeType": "text",
                      "content": null
                    }
                  ],
                  "nodeType": "paragraph"
                }
```
```
error Building static HTML for pages failed

See our docs page on debugging HTML builds for help https://goo.gl/yL9lND

  814 |   if (richTextTypes_es5_1.isText(node)) {
  815 |     var nodeValue = escapeHtml_1(node.value);
> 816 |     if (node.marks.length > 0) {
      | ^
  817 |       return node.marks.reduce(function(value, mark) {
  818 |         if (!renderMark[mark.type]) {
  819 |           return value;


  WebpackError: TypeError: Cannot read property 'length' of undefined

  - rich-text-html-renderer.es5.js:816 nodeToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:816:1

  - rich-text-html-renderer.es5.js:804
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:804:1


  - rich-text-html-renderer.es5.js:803 nodeListToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:803:1

  - rich-text-html-renderer.es5.js:827 nextNode
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:827:1

  - rich-text-html-renderer.es5.js:767 Object../node_modules/@contentful/rich-te    xt-html-renderer/dist/rich-text-html-renderer.es5.js._a.(anonymous function)     [as hyperlink]
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:767:1

  - rich-text-html-renderer.es5.js:836 nodeToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:836:1

  - rich-text-html-renderer.es5.js:804
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:804:1


  - rich-text-html-renderer.es5.js:803 nodeListToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:803:1

  - rich-text-html-renderer.es5.js:827 nextNode
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:827:1

  - rich-text-html-renderer.es5.js:719 Object../node_modules/@contentful/rich-te    xt-html-renderer/dist/rich-text-html-renderer.es5.js._a.(anonymous function)     [as paragraph]
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:719:1

  - rich-text-html-renderer.es5.js:836 nodeToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:836:1

  - rich-text-html-renderer.es5.js:804
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:804:1


  - rich-text-html-renderer.es5.js:803 nodeListToHtmlString
    [lib]/[@contentful]/rich-text-html-renderer/dist/rich-text-html-renderer.es5    .js:803:1
```