### PR TITLE
fix: gracefully handle empty rich text documents

### DIFF
--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -267,4 +267,12 @@ describe('documentToHtmlString', () => {
 
     expect(documentToHtmlString(document)).toEqual(expected);
   });
+
+  it('does not crash with empty documents', () => {
+    expect(documentToHtmlString({} as Document)).toEqual('');
+  });
+
+  it('does not crash with undefined documents', () => {
+    expect(documentToHtmlString(undefined as Document)).toEqual('');
+  });
 });

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -77,6 +77,10 @@ export function documentToHtmlString(
   richTextDocument: Document,
   options: Partial<Options> = {},
 ): string {
+  if (!richTextDocument || !richTextDocument.content) {
+    return '';
+  }
+
   return nodeListToHtmlString(richTextDocument.content, {
     renderNode: {
       ...defaultNodeRenderers,


### PR DESCRIPTION
Hello!

I ran into an issue where we had empty rich text fields, as we wanted to release the code that read the fields before we actually finalized the copy, and `documentToHtmlString` throws when passed an empty document. 

I don't know if this is actually considered an issue, as it is reasonable to say that invalid input throws, but it feels safer to me to just return an empty string instead of throwing. I was going to open an issue but I figured it was simple enough to just open a PR and discuss it here.

Thanks for taking the time to consider this PR.