### PR TITLE
Feature/react text render option

### DIFF
--- a/packages/rich-text-react-renderer/README.md
+++ b/packages/rich-text-react-renderer/README.md
@@ -109,10 +109,11 @@ const options = {
   renderNode: {
     [BLOCKS.PARAGRAPH]: (node, children) => <Text>{children}</Text>,
   },
+  renderText: text => text.replace('!', '?'),
 };
 
 documentToReactComponents(document, options);
-// -> <p class="align-center"><p class="bold">Hello</p><u> world!</u></p>
+// -> <p class="align-center"><p class="bold">Hello</p><u> world?</u></p>
 ```
 
 Last, but not least, you can pass a custom rendering component for an embedded entry:
@@ -186,9 +187,21 @@ The `renderMark` keys should be one of the following `MARKS` properties as defin
 - `UNDERLINE`
 - `CODE`
 
+The `renderText` callback is a function that has a single string argument and returns a React node. Each text node is evaluated individually by this callback. A possible use case for this is to replace instances of `\n` produced by `Shift + Enter` with `<br/>` React elements. This could be accomplished in the following way:
+
+```javascript
+const options = {
+  renderText: text => {
+    return text.split('\n').reduce((children, textSegment, index) => {
+      return [...children, index > 0 && <br key={index} />, textSegment];
+    }, []);
+  },
+};
+```
+
 #### Note on adding a `key` prop in custom renderers:
 
-It is possible to pass a `key` prop in the components returned by custom renderes. A good use case for this is in embeded entries using the node's `target.sys.id`. It is important not to pass anything that is index-like (e.g. 1 or "1") as it may clash with the default renders which automatically inject a `key` prop using their index in the Contentful rich text AST.
+It is possible to pass a `key` prop in the components returned by custom renderers. A good use case for this is in embeded entries using the node's `target.sys.id`. It is important not to pass anything that is index-like (e.g. 1 or "1") as it may clash with the default renderers which automatically inject a `key` prop using their index in the Contentful rich text AST.
 
 To work around this limitation, just append any non-numeric character to your custom key.
 

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -144,7 +144,7 @@ Array [
 ]
 `;
 
-exports[`documentToReactComponents renders marks with the passed custom mark rendered 1`] = `
+exports[`documentToReactComponents renders marks with the passed custom mark renderer 1`] = `
 Array [
   <p>
     <i>
@@ -223,6 +223,22 @@ Array [
 ]
 `;
 
+exports[`documentToReactComponents renders text with the passed custom text renderer 1`] = `
+Array [
+  <p>
+    hello Earth
+  </p>,
+]
+`;
+
+exports[`documentToReactComponents renders unaltered text with default text renderer 1`] = `
+Array [
+  <p>
+    hello world
+  </p>,
+]
+`;
+
 exports[`documentToReactComponents renders unordered lists 1`] = `
 Array [
   <ul>
@@ -274,5 +290,30 @@ exports[`nodeToReactComponent renders valid marks 1`] = `
 exports[`nodeToReactComponent renders valid nodes 1`] = `
 <p>
   hello world
+</p>
+`;
+
+exports[`nodeToReactComponent with custom text renderer does not render altered text with default text renderer 1`] = `
+<p>
+  <b>
+    some
+lines
+of
+text
+  </b>
+</p>
+`;
+
+exports[`nodeToReactComponent with custom text renderer renders altered text with custom text renderer 1`] = `
+<p>
+  <b>
+    some
+    <br />
+    lines
+    <br />
+    of
+    <br />
+    text
+  </b>
 </p>
 `;

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -275,6 +275,31 @@ Array [
 
 exports[`nodeToReactComponent does not add additional tags on invalid marks 1`] = `"hello world"`;
 
+exports[`nodeToReactComponent does not render altered text with default text renderer 1`] = `
+<p>
+  <b>
+    some
+lines
+of
+text
+  </b>
+</p>
+`;
+
+exports[`nodeToReactComponent renders altered text with custom text renderer 1`] = `
+<p>
+  <b>
+    some
+    <br />
+    lines
+    <br />
+    of
+    <br />
+    text
+  </b>
+</p>
+`;
+
 exports[`nodeToReactComponent renders invalid node types in React fragments 1`] = `
 <React.Fragment>
   hello world
@@ -290,30 +315,5 @@ exports[`nodeToReactComponent renders valid marks 1`] = `
 exports[`nodeToReactComponent renders valid nodes 1`] = `
 <p>
   hello world
-</p>
-`;
-
-exports[`nodeToReactComponent with custom text renderer does not render altered text with default text renderer 1`] = `
-<p>
-  <b>
-    some
-lines
-of
-text
-  </b>
-</p>
-`;
-
-exports[`nodeToReactComponent with custom text renderer renders altered text with custom text renderer 1`] = `
-<p>
-  <b>
-    some
-    <br />
-    lines
-    <br />
-    of
-    <br />
-    text
-  </b>
 </p>
 `;

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -147,9 +147,11 @@ Array [
 exports[`documentToReactComponents renders marks with the passed custom mark rendered 1`] = `
 Array [
   <p>
-    <Strong>
-      hello world
-    </Strong>
+    <i>
+      <Strong>
+        hello world
+      </Strong>
+    </i>
   </p>,
 ]
 `;
@@ -193,8 +195,11 @@ Array [
 exports[`documentToReactComponents renders nodes with passed custom node renderer 1`] = `
 Array [
   <Paragraph>
-    hello world
+    hello
   </Paragraph>,
+  <blockquote>
+    world
+  </blockquote>,
 ]
 `;
 

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -93,7 +93,7 @@ describe('documentToReactComponents', () => {
 
   it('renders text with the passed custom text renderer', () => {
     const options: Options = {
-      renderText: text => text.replace(/world/, 'Earth')
+      renderText: text => text.replace(/world/, 'Earth'),
     };
     const document: Document = paragraphDoc;
 
@@ -282,36 +282,34 @@ describe('nodeToReactComponent', () => {
     expect(nodeToReactComponent(createTextNode(MARKS.ITALIC), options)).toMatchSnapshot();
   });
 
-  describe('with custom text renderer', () => {
-    const node: CommonNode = {
-      nodeType: BLOCKS.PARAGRAPH,
-      data: {},
-      content: [
-        {
-          nodeType: 'text',
-          value: 'some\nlines\nof\ntext',
-          marks: [{ type: MARKS.BOLD }],
-          data: {},
-        },
-      ],
-    };
-
-    const optionsWithTextRenderer = {
-      ...options,
-      renderText: (text: string): ReactNode => {
-        return text.split('\n').reduce((children, textSegment, index) => {
-          return [...children, index > 0 && <br key={index} />, textSegment];
-        }, []);
+  const customTextNode: CommonNode = {
+    nodeType: BLOCKS.PARAGRAPH,
+    data: {},
+    content: [
+      {
+        nodeType: 'text',
+        value: 'some\nlines\nof\ntext',
+        marks: [{ type: MARKS.BOLD }],
+        data: {},
       },
-    };
+    ],
+  };
 
-    it('does not render altered text with default text renderer', () => {
-      expect(nodeToReactComponent(node, options)).toMatchSnapshot();
-    });
+  it('does not render altered text with default text renderer', () => {
+    expect(nodeToReactComponent(customTextNode, options)).toMatchSnapshot();
+  });
 
-    it('renders altered text with custom text renderer', () => {
-      expect(nodeToReactComponent(node, optionsWithTextRenderer)).toMatchSnapshot();
-    });
+  it('renders altered text with custom text renderer', () => {
+    expect(
+      nodeToReactComponent(customTextNode, {
+        ...options,
+        renderText: (text: string): ReactNode => {
+          return text.split('\n').reduce((children, textSegment, index) => {
+            return [...children, index > 0 && <br key={index} />, textSegment];
+          }, []);
+        },
+      }),
+    ).toMatchSnapshot();
   });
 });
 

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -71,7 +71,7 @@ describe('documentToReactComponents', () => {
         [BLOCKS.PARAGRAPH]: (node, children) => <Paragraph>{children}</Paragraph>,
       },
     };
-    const document: Document = paragraphDoc;
+    const document: Document = quoteDoc;
     expect(documentToReactComponents(document, options)).toMatchSnapshot();
   });
 
@@ -81,7 +81,7 @@ describe('documentToReactComponents', () => {
         [MARKS.BOLD]: text => <Strong>{text}</Strong>,
       },
     };
-    const document: Document = marksDoc(MARKS.BOLD);
+    const document: Document = multiMarkDoc();
 
     expect(documentToReactComponents(document, options)).toMatchSnapshot();
   });

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -51,6 +51,10 @@ export interface RenderMark {
   [k: string]: (text: ReactNode) => ReactNode;
 }
 
+export interface RenderText {
+  (text: string): ReactNode;
+}
+
 export interface Options {
   /**
    * Node renderers
@@ -60,6 +64,10 @@ export interface Options {
    * Mark renderers
    */
   renderMark?: RenderMark;
+  /**
+   * Text renderer
+   */
+  renderText?: RenderText;
 }
 
 /**
@@ -82,5 +90,6 @@ export function documentToReactComponents(
       ...defaultMarkRenderers,
       ...options.renderMark,
     },
+    renderText: options.renderText
   });
 }

--- a/packages/rich-text-react-renderer/src/util/nodeListToReactComponents.tsx
+++ b/packages/rich-text-react-renderer/src/util/nodeListToReactComponents.tsx
@@ -12,14 +12,14 @@ export function nodeListToReactComponents(nodes: CommonNode[], options: Options)
 }
 
 export function nodeToReactComponent(node: CommonNode, options: Options): ReactNode {
-  const { renderNode, renderMark } = options;
+  const { renderNode, renderMark, renderText } = options;
   if (helpers.isText(node)) {
     return node.marks.reduce((value: ReactNode, mark: Mark): ReactNode => {
       if (!renderMark[mark.type]) {
         return value;
       }
       return renderMark[mark.type](value);
-    }, node.value);
+    }, renderText ? renderText(node.value) : node.value);
   } else {
     const children: ReactNode = nodeListToReactComponents(node.content, options);
     if (!node.nodeType || !renderNode[node.nodeType]) {


### PR DESCRIPTION
Adding a renderText option to the React renderer to affect all text nodes. In the HTML renderer, this is not an issue, as it is a just a string that can be altered post-processing. The React renderer, however, produces a tree which means changing all text nodes can be done by either overwriting all of the default renderers which is error-prone or by traversing the entire tree using the React.Children helpers which would be slow.

There have already been multiple instances where devs want to replace `\n` with `<br/>` in all instances of it occurring regardless of where in the rich text. This feature would allow for a simpler solution to this problem without having to traverse non text nodes or write unnecessary custom renderer components.

Also updated some of the previous tests to ensure that documentToReactComponents was also testing default renderers concurrently with custom renderers. Previously, custom renderers were being tested in isolation.