### PR TITLE
Deprecate gatsby-transformer-contentful-richtext

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Text documents.
   - Converts rich text documents to plain text
 - [`rich-text-types`](https://github.com/contentful/rich-text/tree/master/packages/rich-text-types)
   - Type definitions and constants for the rich text field type
-- [`gatsby-transformer-contentful-richtext`](https://github.com/contentful/rich-text/tree/master/packages/gatsby-transformer-contentful-richtext)
+- [`gatsby-transformer-contentful-richtext`](https://github.com/contentful/rich-text/tree/master/packages/gatsby-transformer-contentful-richtext) [DEPRECATED]
   - Parses a Contentful Rich Text document to HTML in Gatsby
 - [`rich-text-react-renderer`](https://github.com/contentful/rich-text/tree/master/packages/rich-text-react-renderer)
   - Parses a Contentful Rich Text document to React components

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
     '!packages/gatsby-transformer-contentful-richtext/*.js',
   ],
   roots: ['packages/'],
-  testPathIgnorePatterns: ['/dist/'],
+  testPathIgnorePatterns: ['/dist/', '/gatsby-transformer-contentful-richtext/'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,12 @@
   "lerna": "2.7.2",
   "version": "13.2.0",
   "packages": [
-    "packages/*"
+    "packages/rich-text-from-markdown",
+    "packages/rich-text-html-renderer",
+    "packages/rich-text-links",
+    "packages/rich-text-plain-text-renderer",
+    "packages/rich-text-react-renderer",
+    "packages/rich-text-types"
   ],
   "command": {
     "bootstrap": {

--- a/packages/gatsby-transformer-contentful-richtext/README.md
+++ b/packages/gatsby-transformer-contentful-richtext/README.md
@@ -1,3 +1,58 @@
+# DEPRECATED
+
+Package `@contentful/gatsby-transformer-contentful-richtext` no longer maintained and deprecated in favour of `gatsby-source-contentful` and `@contentful/rich-text-react-renderer`.
+
+## Reasons for deprecation
+
+We've built Rich Text with the idea that developers have full control over the presentation of the Rich Text documents.
+Although Transformer Plugins are an excellent solution for the data transformation, it's not like that for the rendering:
+
+- lack of flexibility: existing plugin api forces to have only one place for defining resolvers (in `gatsby-config.js`) which makes it impossible to influence rendering depending on the context (e.g. use different components in header and footer).
+
+- no jsx support: it is not possible to use React Components inside `gatsby-config.js` file.
+
+## Replacement
+
+The long-term replacement for `@contentful/gatsby-transformer-contentful-richtext` is a combination of `gatsby-source-contentful` and `@contentful/rich-text-react-renderer` packages.
+
+JSON output is accessible on the Rich Text Node, see example query:
+
+```graphql
+{
+  allContentfulBlogPost {
+    edges {
+      node {
+        bodyRichText {
+          json
+        }
+      }
+    }
+  }
+}
+```
+
+The following snippet shows a way to define how Rich Text document is rendered:
+
+```js
+import React from 'react';
+import { BLOCKS, MARKS } from '@contentful/rich-text-types';
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+
+const Bold = ({ children }) => <span className="bold">{children}</span>;
+const Text = ({ children }) => <p className="align-center">{children}</p>;
+
+const options = {
+  renderMark: {
+    [MARKS.BOLD]: text => <Bold>{text}</Bold>,
+  },
+  renderNode: {
+    [BLOCKS.PARAGRAPH]: (node, children) => <Text>{children}</Text>,
+  },
+};
+
+documentToReactComponents(node.bodyRichText.json, options);
+```
+
 # gatsby-transformer-contentful-richtext
 
 Parses Contentful Rich Text document
@@ -11,7 +66,7 @@ npm install --save @contentful/gatsby-transformer-contentful-richtext
 ## How to use
 
 ```js
-plugins: [`@contentful/gatsby-transformer-contentful-richtext`]
+plugins: [`@contentful/gatsby-transformer-contentful-richtext`];
 ```
 
 ## Query
@@ -36,7 +91,7 @@ After adding the plugin you will be able to query the html representation of the
 
 ```js
 // npm i @contentful/rich-text-types
-const { BLOCKS, MARKS, INLINES } = require('@contentful/rich-text-types')
+const { BLOCKS, MARKS, INLINES } = require('@contentful/rich-text-types');
 module.exports = {
   siteMetadata: {
     title: 'Gatsby Default Starter',
@@ -71,8 +126,7 @@ module.exports = {
       resolve: 'gatsby-source-contentful',
       options: {
         spaceId: '<space-id>',
-        accessToken:
-          '<access-token>',
+        accessToken: '<access-token>',
       },
     },
     {
@@ -87,12 +141,10 @@ module.exports = {
             [INLINES.ASSET_HYPERLINK]: node => {
               return `<img class='custom-asset' src="${
                 node.data.target.fields.file['en-US'].url
-              }"/>`
+              }"/>`;
             },
             [INLINES.EMBEDDED_ENTRY]: node => {
-              return `<div class='custom-entry' />${
-                node.data.target.fields.name['en-US']
-              }</div>`
+              return `<div class='custom-entry' />${node.data.target.fields.name['en-US']}</div>`;
             },
           },
           /*
@@ -106,7 +158,7 @@ module.exports = {
       },
     },
   ],
-}
+};
 ```
 
 The `renderNode` keys should be one of the following `BLOCKS` and `INLINES` properties as defined in [`@contentful/rich-text-types`](https://www.npmjs.com/package/@contentful/rich-text-types):


### PR DESCRIPTION
PR adds deprecation notes for `gatsby-transformer-contentful-richtext` packages.