### PR TITLE
refactor: 💡 Use named export for getRichTextEntityLinks

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -1,5 +1,5 @@
 import { Document, BLOCKS, INLINES } from '../../node_modules/@contentful/rich-text-types';
-import richTextLinks from '../index';
+import { getRichTextEntityLinks } from '../index';
 
 describe('getRichTextEntityLinks', () => {
   describe('returning top-level rich text links', () => {
@@ -43,7 +43,7 @@ describe('getRichTextEntityLinks', () => {
     };
 
     it('returns all entity link objects', () => {
-      expect(richTextLinks.getRichTextEntityLinks(document)).toEqual({
+      expect(getRichTextEntityLinks(document)).toEqual({
         Entry: [
           {
             linkType: 'Entry',
@@ -159,7 +159,7 @@ describe('getRichTextEntityLinks', () => {
     };
 
     it('returns all entity link objects', () => {
-      expect(richTextLinks.getRichTextEntityLinks(document)).toEqual({
+      expect(getRichTextEntityLinks(document)).toEqual({
         Entry: [
           {
             linkType: 'Entry',
@@ -293,7 +293,7 @@ describe('getRichTextEntityLinks', () => {
     };
 
     it('ignores all redundant links', () => {
-      expect(richTextLinks.getRichTextEntityLinks(document)).toEqual({
+      expect(getRichTextEntityLinks(document)).toEqual({
         Entry: [
           {
             linkType: 'Entry',
@@ -353,7 +353,7 @@ describe('getRichTextEntityLinks', () => {
     };
 
     it('ignores all links of different types', () => {
-      expect(richTextLinks.getRichTextEntityLinks(document, BLOCKS.EMBEDDED_ENTRY)).toEqual({
+      expect(getRichTextEntityLinks(document, BLOCKS.EMBEDDED_ENTRY)).toEqual({
         Entry: [
           {
             linkType: 'Entry',

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -12,7 +12,7 @@ export type EntityLinkNodeData = {
 /**
  *  Extracts entity links from a Rich Text document.
  */
-function getRichTextEntityLinks(
+export function getRichTextEntityLinks(
   /**
    *  An instance of a Rich Text Document.
    */
@@ -99,7 +99,3 @@ function iteratorToArray<T>(iterator: IterableIterator<T>): T[] {
 
   return result;
 }
-
-export default {
-  getRichTextEntityLinks,
-};


### PR DESCRIPTION
So that TypeScript in graph-api stops reporting an import error.