### PR TITLE
Add Flutter renderer to community-made section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Text documents.
 
 - [`rich-text-to-jsx`](https://github.com/connor-baer/rich-text-to-jsx)
   - Opinionated JSX renderer for the Contentful rich text field type
+- [`rich-text-flutter`](https://github.com/Kumanu/contentful-rich-text-flutter)
+  - Flutter renderer for the Contentful rich text field type (work in progress)
 
 ## About Rich Text
 


### PR DESCRIPTION
Started a rich-text renderer for Flutter (written in Dart) and wanted to share it with the community. We are interested in help fleshing out the various widgets, and it is still in a relatively early "work-in-progress" phase. But it does work, it allows Flutter widgets to be passed in to override the defaults and has the basic widgets defined so far. It was loosely based on the Contentful Typescript renderer.

Also happy to get issue reports and code reviews (probably could use some cleanup), but time to work on them may be limited for the next month or two.

Fixes #82 