### PR TITLE
fix shape of embedded node in README

### DIFF
--- a/packages/rich-text-react-renderer/README.md
+++ b/packages/rich-text-react-renderer/README.md
@@ -144,7 +144,7 @@ const CustomComponent = ({ title, description }) => (
 const options = {
   renderNode: {
     [BLOCKS.EMBEDDED_ENTRY]: (node) => {
-      const { title, description } = node.target.fields;
+      const { title, description } = node.data.target.fields;
       return <CustomComponent title={title} description={description} />
     }
   }


### PR DESCRIPTION
Hey, while integrating this feature I noticed the shape of data is incorrect in the README