### PR TITLE
feat: 🎸 Adds BLOCKS.DOCUMENT renderer support to react-renderer

### DIFF
--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -193,14 +193,14 @@ Array [
 `;
 
 exports[`documentToReactComponents renders nodes with passed custom node renderer 1`] = `
-Array [
+<Document>
   <Paragraph>
     hello
-  </Paragraph>,
+  </Paragraph>
   <blockquote>
     world
-  </blockquote>,
-]
+  </blockquote>
+</Document>
 `;
 
 exports[`documentToReactComponents renders ordered lists 1`] = `

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -259,6 +259,18 @@ Array [
 ]
 `;
 
+exports[`documentToReactComponents returns an array of elements when given a populated document 1`] = `
+Array [
+  <p>
+    hello world
+  </p>,
+  <hr />,
+  <p>
+    
+  </p>,
+]
+`;
+
 exports[`nodeListToReactComponents renders children as an array with keys from its index 1`] = `
 Array [
   <p>

--- a/packages/rich-text-react-renderer/src/__test__/components/Document.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/components/Document.tsx
@@ -1,0 +1,11 @@
+import React, { FunctionComponent, ReactNode } from 'react';
+
+type DocumentProps = {
+  children: ReactNode;
+};
+
+const Document: FunctionComponent<DocumentProps> = ({ children }) => {
+  return <section>{children}</section>;
+};
+
+export default Document;

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -18,6 +18,7 @@ import {
   quoteDoc,
   ulDoc,
 } from './documents';
+import DocumentWrapper from './components/Document';
 import Paragraph from './components/Paragraph';
 import Strong from './components/Strong';
 import { appendKeyToValidElement } from '../util/appendKeyToValidElement';
@@ -73,6 +74,7 @@ describe('documentToReactComponents', () => {
   it('renders nodes with passed custom node renderer', () => {
     const options: Options = {
       renderNode: {
+        [BLOCKS.DOCUMENT]: (node, children) => <DocumentWrapper>{children}</DocumentWrapper>,
         [BLOCKS.PARAGRAPH]: (node, children) => <Paragraph>{children}</Paragraph>,
       },
     };

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -35,6 +35,13 @@ describe('documentToReactComponents', () => {
     expect(documentToReactComponents(document)).toEqual([]);
   });
 
+  it('returns an array of elements when given a populated document', () => {
+    const document: Document = hrDoc;
+
+    expect(documentToReactComponents(document)).toMatchSnapshot();
+    expect(documentToReactComponents(document)).toBeInstanceOf(Array);
+  });
+
   it('renders nodes with default node renderer', () => {
     const docs: Document[] = [
       paragraphDoc,

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -1,8 +1,9 @@
 import React, { ReactNode } from 'react';
 import { Block, BLOCKS, Document, Inline, INLINES, MARKS, Text } from '@contentful/rich-text-types';
-import { nodeListToReactComponents } from './util/nodeListToReactComponents';
+import { nodeToReactComponent } from './util/nodeListToReactComponents';
 
 const defaultNodeRenderers: RenderNode = {
+  [BLOCKS.DOCUMENT]: (node, children) => children,
   [BLOCKS.PARAGRAPH]: (node, children) => <p>{children}</p>,
   [BLOCKS.HEADING_1]: (node, children) => <h1>{children}</h1>,
   [BLOCKS.HEADING_2]: (node, children) => <h2>{children}</h2>,
@@ -77,11 +78,11 @@ export function documentToReactComponents(
   richTextDocument: Document,
   options: Options = {},
 ): ReactNode {
-  if (!richTextDocument || !richTextDocument.content) {
+  if (!richTextDocument) {
     return null;
   }
 
-  return nodeListToReactComponents(richTextDocument.content, {
+  return nodeToReactComponent(richTextDocument, {
     renderNode: {
       ...defaultNodeRenderers,
       ...options.renderNode,
@@ -90,6 +91,6 @@ export function documentToReactComponents(
       ...defaultMarkRenderers,
       ...options.renderMark,
     },
-    renderText: options.renderText
+    renderText: options.renderText,
   });
 }


### PR DESCRIPTION
Enables the option renderNode[BLOCKS.DOCUMENT] with
rich-text-react-renderer, defaulting to current Array output.

✅ Closes: #104

I kept the existing behaviour of rendering an array of ReactNodes to avoid breaking existing uses. Specifying `renderNode[BLOCKS.DOCUMENT]` can enable a root element if wanted.