### PR TITLE
requrie-custome-rendering

### DIFF
--- a/packages/rich-text-html-renderer/README.md
+++ b/packages/rich-text-html-renderer/README.md
@@ -111,7 +111,7 @@ documentToHtmlString(document, options);
 // -> <custom-paragraph><custom-bold>Hello</custom-bold><u> world!</u></custom-paragraph>
 ```
 
-Last, but not least, you can pass a custom rendering component for an embedded entry:
+Last, but not least, if you use `EMBEDDED_ASSET` or `EMBEDDED_ASSET` you must pass a custom rendering component for render them:
 
 ```javascript
 import { BLOCKS } from '@contentful/rich-text-types';
@@ -143,6 +143,7 @@ documentToHtmlString(document, options);
 The `renderNode` keys should be one of the following `BLOCKS` and `INLINES` properties as defined in [`@contentful/rich-text-types`](https://www.npmjs.com/package/@contentful/rich-text-types):
 
 - `BLOCKS`
+
   - `DOCUMENT`
   - `PARAGRAPH`
   - `HEADING_1`

--- a/packages/rich-text-react-renderer/README.md
+++ b/packages/rich-text-react-renderer/README.md
@@ -33,7 +33,7 @@ const document = {
           nodeType: 'text',
           value: 'Hello world!',
           marks: [],
-          data: {}
+          data: {},
         },
       ],
     },
@@ -116,7 +116,7 @@ documentToReactComponents(document, options);
 // -> <p class="align-center"><p class="bold">Hello</p><u> world?</u></p>
 ```
 
-Last, but not least, you can pass a custom rendering component for an embedded entry:
+Last, but not least, if you use `EMBEDDED_ASSET` or `EMBEDDED_ASSET` you must pass a custom rendering component for render them:
 
 ```javascript
 import { BLOCKS } from '@contentful/rich-text-types';


### PR DESCRIPTION
https://github.com/contentful/rich-text/issues/58

Add to make it clean that it is required if you use `EMBEDDED_ASSET` or `EMBEDDED_ASSET` in rich text