### PR TITLE
feat: Add a backwards compatable version of toReactComponents

### DIFF
--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
-import { Block, BLOCKS, Document, Inline, INLINES, MARKS, Text } from '@contentful/rich-text-types';
-import { nodeToReactComponent } from './util/nodeListToReactComponents';
+import { Block, BLOCKS, Document, TopLevelBlock, Inline, INLINES, MARKS, Text } from '@contentful/rich-text-types';
+import { nodeToReactComponent, nodeListToReactComponents } from './util/nodeListToReactComponents';
 
 const defaultNodeRenderers: RenderNode = {
   [BLOCKS.DOCUMENT]: (node, children) => children,
@@ -82,7 +82,31 @@ export function documentToReactComponents(
     return null;
   }
 
-  return nodeToReactComponent(richTextDocument, {
+  return toReactComponents(richTextDocument, nodeToReactComponent, options);
+}
+
+/**
+ * Serialize a list of entities inside a Contentful Rich Text
+ * `document` to a react tree
+ */
+export function nodesToReactComponents(
+  richTextNodes: TopLevelBlock[],
+  options: Options = {},
+): ReactNode {
+  if (!richTextNodes || !richTextNodes.length) {
+    return null
+  }
+
+  return toReactComponents(richTextNodes, nodeListToReactComponents, options);
+}
+
+function toReactComponents(
+  nodes: any,
+  nodesToReactComponents: Function,
+  options: Options = {}
+): ReactNode {
+
+  return nodesToReactComponents(nodes, {
     renderNode: {
       ...defaultNodeRenderers,
       ...options.renderNode,
@@ -92,5 +116,5 @@ export function documentToReactComponents(
       ...options.renderMark,
     },
     renderText: options.renderText,
-  });
+  })
 }


### PR DESCRIPTION
13.4.0 introduced a regression for us.

Where we were passing a list of nodes to render documents, 
we now require entire documents.

This change will allow you to pass a list of nodes, rather than requiring an
entire document, and therefore allow rendering sub parts of the
document tree.