### PR TITLE
[PEN-782] fix: 🐛 detect links as children of nodes also having links

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -69,7 +69,15 @@ describe('getRichTextEntityLinks', () => {
       content: [
         {
           nodeType: BLOCKS.PARAGRAPH,
-          data: {},
+          data: {
+            target: {
+              sys: {
+                linkType: 'Entry',
+                type: 'Link',
+                id: 'foo',
+              },
+            },
+          },
           content: [
             {
               nodeType: BLOCKS.EMBEDDED_ENTRY,
@@ -78,7 +86,7 @@ describe('getRichTextEntityLinks', () => {
                   sys: {
                     linkType: 'Entry',
                     type: 'Link',
-                    id: 'foo',
+                    id: 'bar',
                   },
                 },
               },
@@ -147,7 +155,7 @@ describe('getRichTextEntityLinks', () => {
                   sys: {
                     linkType: 'Asset',
                     type: 'Link',
-                    id: 'bar',
+                    id: 'qux',
                   },
                 },
               },
@@ -164,19 +172,24 @@ describe('getRichTextEntityLinks', () => {
           {
             linkType: 'Entry',
             type: 'Link',
+            id: 'foo',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
             id: 'baz',
           },
           {
             linkType: 'Entry',
             type: 'Link',
-            id: 'foo',
+            id: 'bar',
           },
         ],
         Asset: [
           {
             linkType: 'Asset',
             type: 'Link',
-            id: 'bar',
+            id: 'qux',
           },
           {
             linkType: 'Asset',

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -47,7 +47,9 @@ function addLinksFromRichTextNode(node: Node, links: EntityLinkMaps, type?: stri
 
     if (hasRequestedNodeType && isLinkObject(data)) {
       links[data.target.sys.linkType].set(data.target.sys.id, data.target.sys);
-    } else if (Array.isArray(content)) {
+    }
+
+    if (Array.isArray(content)) {
       for (const childNode of content) {
         toCrawl.push(childNode);
       }


### PR DESCRIPTION
## Summary

We have previously been treating nodes having `content` and nodes having `data` as being mutually exclusive. The result is that `rich-text-links` ignores the `content` of nodes that are parents to nodes containing embedded block or inline entity links*.

* NB: this tool doesn't technically check the `nodeType`, that's just the most common use-case so I refer to it here for clarity's sake.

## Risks

Technically, I think this runs against spec but our UI behaves otherwise and in any case I don't really see the harm (philosophically) in making this a dumb scraper for `data` nodes with entity links.

Performance-wise, this moves the tool from seeking for only a subset of all nodes (those without `data` attributes) to _all_ nodes within a document. I think this is low-risk (since documents generated by our UI shouldn't be producing such markup anyway) but we need to take note of it if this merged / bumped / incorporated into our other packages as it could have performance implications, particularly for the UI.

## Dependencies & References

https://contentful.atlassian.net/browse/PEN-782