### PR TITLE
fix(rich-text-types): Update marks.ts to support stronger TS

### DIFF
--- a/packages/rich-text-types/src/marks.ts
+++ b/packages/rich-text-types/src/marks.ts
@@ -1,9 +1,11 @@
 /**
  * Map of all Contentful marks.
  */
-export default {
+const MARKS = {
   BOLD: 'bold',
   ITALIC: 'italic',
   UNDERLINE: 'underline',
   CODE: 'code',
-};
+} as const;
+
+export default MARKS;


### PR DESCRIPTION
Alternative to #136.

### The Problem
As of `@contentful/rich-text-types@14.1.2` the generated TS definition file found in `node_modules/@contentful/rich-text-types/dist/types/marks.d.ts` looks like:

```ts
declare const _default: {
    BOLD: string;
    ITALIC: string;
    UNDERLINE: string;
    CODE: string;
};
/**
 * Map of all Contentful marks.
 */
export default _default;
```

This prevents any strong typing such as `type Mark = typeof MARKS[keyof typeof MARKS];` which is equivalent to `type Mark = string;` given the current code. Ideally, this should result in `type Mark = 'bold' | 'italic' | 'underline' | 'code'`;

### The Solution
Adding a const assertion (`as const`) to the end of the MARKS declaration the object literals gets readonly properties. This is supported as of Typescript v3.4
