### PR TITLE
fix: 🐛 prevent html injection via `data.uri` link rendering

### DIFF
--- a/packages/rich-text-html-renderer/package-lock.json
+++ b/packages/rich-text-html-renderer/package-lock.json
@@ -569,6 +569,21 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.171",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.171.tgz",
+      "integrity": "sha512-7eQ2xYLLI/LsicL2nejW9Wyko3lcpN6O/z0ZLHrEQsg280zIdCv1t/0m6UtBjUHokCGBQ3gYTbHzDkZ1xOBwwg==",
+      "dev": true
+    },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.7.tgz",
@@ -2996,6 +3011,12 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
     "lodash.memoize": {

--- a/packages/rich-text-html-renderer/package.json
+++ b/packages/rich-text-html-renderer/package.json
@@ -29,7 +29,9 @@
   },
   "devDependencies": {
     "@types/escape-html": "0.0.20",
+    "@types/lodash.clonedeep": "^4.5.6",
     "jest": "^24.7.1",
+    "lodash.clonedeep": "^4.5.0",
     "rimraf": "^2.6.3",
     "rollup": "^1.11.0",
     "rollup-plugin-commonjs": "^9.3.4",

--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -1,5 +1,5 @@
-import { Document, BLOCKS, MARKS, INLINES } from '@contentful/rich-text-types';
-
+import cloneDeep from 'lodash/cloneDeep';
+import { Document, Block, BLOCKS, MARKS, INLINES } from '@contentful/rich-text-types';
 import { documentToHtmlString, Options } from '../index';
 import {
   hrDoc,
@@ -223,6 +223,23 @@ describe('documentToHtmlString', () => {
   it('renders hyperlink', () => {
     const document: Document = hyperlinkDoc;
     const expected = '<p>Some text <a href="https://url.org">link</a> text.</p>';
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
+  it('renders hyperlink without allowing html injection via `data.uri`', () => {
+    const document: Document = cloneDeep(hyperlinkDoc);
+    (document.content[0].content[1] as Block).data.uri = '">no html injection!<a href="';
+    const expected =
+      '<p>Some text <a href="&quot;>no html injection!<a href=&quot;">link</a> text.</p>';
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
+  it('renders hyperlink without invalid non-string `data.uri` values', () => {
+    const document: Document = cloneDeep(hyperlinkDoc);
+    (document.content[0].content[1] as Block).data.uri = 42;
+    const expected = '<p>Some text <a href="">link</a> text.</p>';
 
     expect(documentToHtmlString(document)).toEqual(expected);
   });

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -48,7 +48,7 @@ const defaultMarkRenderers: RenderMark = {
 };
 
 const defaultInline = (type: string, node: Inline) =>
-  `<span>type: ${type} id: ${node.data.target.sys.id}</span>`;
+  `<span>type: ${escape(type)} id: ${escape(node.data.target.sys.id)}</span>`;
 
 export type CommonNode = Text | Block | Inline;
 

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -12,6 +12,8 @@ import {
 } from '@contentful/rich-text-types';
 import React from 'react';
 
+const attributeValue = (value: string) => `"${value.replace(/"/g, '&quot;')}"`;
+
 const defaultNodeRenderers: RenderNode = {
   [BLOCKS.PARAGRAPH]: (node, next) => `<p>${next(node.content)}</p>`,
   [BLOCKS.HEADING_1]: (node, next) => `<h1>${next(node.content)}</h1>`,
@@ -32,7 +34,10 @@ const defaultNodeRenderers: RenderNode = {
   [INLINES.ASSET_HYPERLINK]: node => defaultInline(INLINES.ASSET_HYPERLINK, node as Inline),
   [INLINES.ENTRY_HYPERLINK]: node => defaultInline(INLINES.ENTRY_HYPERLINK, node as Inline),
   [INLINES.EMBEDDED_ENTRY]: node => defaultInline(INLINES.EMBEDDED_ENTRY, node as Inline),
-  [INLINES.HYPERLINK]: (node, next) => `<a href="${node.data.uri}">${next(node.content)}</a>`,
+  [INLINES.HYPERLINK]: (node, next) => {
+    const href = typeof node.data.uri === 'string' ? node.data.uri : '';
+    return `<a href=${attributeValue(href)}>${next(node.content)}</a>`;
+  },
 };
 
 const defaultMarkRenderers: RenderMark = {


### PR DESCRIPTION
Using a `hyperlink` node with e.g. `data.uri = '"><h1>html</h1><a href="'`, it was possible to inject arbitrary HTML next to the actual hyperlink. We encode `"` within the `href` attribute. The same technique should be applied for all attributes if added in the future.