### PR TITLE
fix: 🐛 corrected typings path for rich-text-html-renderer

### DIFF
--- a/packages/rich-text-html-renderer/package.json
+++ b/packages/rich-text-html-renderer/package.json
@@ -2,7 +2,7 @@
   "name": "@contentful/rich-text-html-renderer",
   "version": "15.2.0",
   "main": "dist/rich-text-html-renderer.es5.js",
-  "typings": "dist/types/index.d.ts",
+  "typings": "dist/types/rich-text-html-renderer/src/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes incorrect TS typings dist path as outlined in https://github.com/contentful/rich-text/issues/252#issuecomment-903845323