### PR TITLE
feat(rich-text-types): Add TEXT_CONTAINERS

### DIFF
--- a/packages/rich-text-types/src/__test__/schemaConstraints.test.ts
+++ b/packages/rich-text-types/src/__test__/schemaConstraints.test.ts
@@ -1,0 +1,17 @@
+import BLOCKS from '../blocks';
+import { VOID_BLOCKS, CONTAINERS, TEXT_CONTAINERS } from '../schemaConstraints';
+
+const allKnownBlocks = Object.values(BLOCKS);
+
+describe('schema constraints', () => {
+  it('all block node types are either considered a container or void', () => {
+    const blocks = [
+      BLOCKS.DOCUMENT, // Root block could be in CONTAINERS but isn't.
+      ...VOID_BLOCKS,
+      ...TEXT_CONTAINERS,
+      ...Object.keys(CONTAINERS),
+    ];
+    expect(blocks).toEqual(expect.arrayContaining(allKnownBlocks));
+    expect(blocks.length).toEqual(allKnownBlocks.length);
+  });
+});

--- a/packages/rich-text-types/src/schemaConstraints.ts
+++ b/packages/rich-text-types/src/schemaConstraints.ts
@@ -86,6 +86,8 @@ export const VOID_BLOCKS = [BLOCKS.HR, BLOCKS.EMBEDDED_ENTRY, BLOCKS.EMBEDDED_AS
 
 /**
  * Dictionary of all container block types, and the set block types they accept as children.
+ *
+ * Note: This does not include `[BLOCKS.DOCUMENT]: TOP_LEVEL_BLOCKS`
  */
 export const CONTAINERS = {
   [BLOCKS.OL_LIST]: [BLOCKS.LIST_ITEM],
@@ -97,6 +99,19 @@ export const CONTAINERS = {
   [BLOCKS.TABLE_CELL]: [BLOCKS.PARAGRAPH],
   [BLOCKS.TABLE_HEADER_CELL]: [BLOCKS.PARAGRAPH],
 };
+
+/**
+ * Array of all block types that may contain text and inline nodes.
+ */
+export const TEXT_CONTAINERS = [
+  BLOCKS.PARAGRAPH,
+  BLOCKS.HEADING_1,
+  BLOCKS.HEADING_2,
+  BLOCKS.HEADING_3,
+  BLOCKS.HEADING_4,
+  BLOCKS.HEADING_5,
+  BLOCKS.HEADING_6,
+];
 
 /**
  * Node types before `tables` release.


### PR DESCRIPTION
`TEXT_CONTAINERS` are all block node types that aren't `CONTAINERS` (block nodes that can contain other block nodes) or void nodes (nodes that do not have any content whatsoever).