### PR TITLE
feat: add toContentfulDocument() and toSlatejsDocument() empty block node handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 				"packages/*"
 			],
 			"dependencies": {
-				"@contentful/rich-text-types": "^5.0.0",
 				"@types/escape-html": "^0.0.20",
 				"@types/lodash": "^4.14.172",
 				"@types/lodash.clonedeep": "^4.5.6",
@@ -35863,10 +35862,10 @@
 		},
 		"packages/contentful-slatejs-adapter": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.6.1",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^5.0.0",
+				"@contentful/rich-text-types": "^15.7.0",
 				"lodash.flatmap": "^4.5.0",
 				"lodash.get": "^4.4.2",
 				"lodash.omit": "^4.5.0"
@@ -35903,14 +35902,6 @@
 				"tslint-config-standard": "^7.0.0",
 				"typescript": "^4.4.2"
 			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"packages/contentful-slatejs-adapter/node_modules/@contentful/rich-text-types": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-5.0.0.tgz",
-			"integrity": "sha512-NPmsk0xCC/OoZUIpZqByFEYCktIcyUakKrzDlSA9YLklCdgahEr6qbSghIsQ/wVclnQhwVq28psJ0agHXdLCSQ==",
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -36215,10 +36206,10 @@
 		},
 		"packages/rich-text-from-markdown": {
 			"name": "@contentful/rich-text-from-markdown",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"lodash": "^4.17.11",
 				"remark-parse": "^6.0.3",
 				"unified": "^7.1.0"
@@ -36242,10 +36233,10 @@
 		},
 		"packages/rich-text-html-renderer": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"escape-html": "^1.0.3"
 			},
 			"devDependencies": {
@@ -36270,10 +36261,10 @@
 		},
 		"packages/rich-text-links": {
 			"name": "@contentful/rich-text-links",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.6.2"
+				"@contentful/rich-text-types": "^15.7.0"
 			},
 			"devDependencies": {
 				"jest": "^27.1.0",
@@ -36294,10 +36285,10 @@
 		},
 		"packages/rich-text-plain-text-renderer": {
 			"name": "@contentful/rich-text-plain-text-renderer",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.6.2"
+				"@contentful/rich-text-types": "^15.7.0"
 			},
 			"devDependencies": {
 				"jest": "^27.1.0",
@@ -36318,10 +36309,10 @@
 		},
 		"packages/rich-text-react-renderer": {
 			"name": "@contentful/rich-text-react-renderer",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.6.2"
+				"@contentful/rich-text-types": "^15.7.0"
 			},
 			"devDependencies": {
 				"@types/react": "^16.8.15",
@@ -36348,38 +36339,9 @@
 				"react-dom": "^16.8.6 || ^17.0.0"
 			}
 		},
-		"packages/rich-text-react-renderer/node_modules/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-			"dev": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"packages/rich-text-react-renderer/node_modules/react-dom": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-			"dev": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
-			},
-			"peerDependencies": {
-				"react": "^16.14.0"
-			}
-		},
 		"packages/rich-text-types": {
 			"name": "@contentful/rich-text-types",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/jest": "^27.0.1",
@@ -37827,7 +37789,7 @@
 		"@contentful/contentful-slatejs-adapter": {
 			"version": "file:packages/contentful-slatejs-adapter",
 			"requires": {
-				"@contentful/rich-text-types": "^5.0.0",
+				"@contentful/rich-text-types": "^15.7.0",
 				"@types/jest": "^27.0.1",
 				"@types/lodash.flatmap": "^4.5.3",
 				"@types/lodash.get": "^4.4.4",
@@ -37863,11 +37825,6 @@
 				"typescript": "^4.4.2"
 			},
 			"dependencies": {
-				"@contentful/rich-text-types": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-5.0.0.tgz",
-					"integrity": "sha512-NPmsk0xCC/OoZUIpZqByFEYCktIcyUakKrzDlSA9YLklCdgahEr6qbSghIsQ/wVclnQhwVq28psJ0agHXdLCSQ=="
-				},
 				"@types/estree": {
 					"version": "0.0.38",
 					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.38.tgz",
@@ -38117,7 +38074,7 @@
 		"@contentful/rich-text-from-markdown": {
 			"version": "file:packages/rich-text-from-markdown",
 			"requires": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"@types/lodash": "^4.14.172",
 				"faker": "^4.1.0",
 				"jest": "^27.1.0",
@@ -38140,7 +38097,7 @@
 		"@contentful/rich-text-html-renderer": {
 			"version": "file:packages/rich-text-html-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"@types/escape-html": "^0.0.20",
 				"@types/lodash.clonedeep": "^4.5.6",
 				"escape-html": "^1.0.3",
@@ -38161,7 +38118,7 @@
 		"@contentful/rich-text-links": {
 			"version": "file:packages/rich-text-links",
 			"requires": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
 				"rollup": "^1.32.1",
@@ -38178,7 +38135,7 @@
 		"@contentful/rich-text-plain-text-renderer": {
 			"version": "file:packages/rich-text-plain-text-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
 				"rollup": "^1.32.1",
@@ -38195,7 +38152,7 @@
 		"@contentful/rich-text-react-renderer": {
 			"version": "file:packages/rich-text-react-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.6.2",
+				"@contentful/rich-text-types": "^15.7.0",
 				"@types/react": "^16.8.15",
 				"@types/react-dom": "^16.8.4",
 				"jest": "^27.1.0",
@@ -38211,31 +38168,6 @@
 				"ts-jest": "^27.0.5",
 				"tslint": "^6.1.3",
 				"typescript": "^4.4.2"
-			},
-			"dependencies": {
-				"react": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-					"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
-				"react-dom": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-					"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.19.1"
-					}
-				}
 			}
 		},
 		"@contentful/rich-text-types": {

--- a/packages/contentful-slatejs-adapter/package-lock.json
+++ b/packages/contentful-slatejs-adapter/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.6.1",
+			"version": "15.7.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^10.0.3",

--- a/packages/contentful-slatejs-adapter/package.json
+++ b/packages/contentful-slatejs-adapter/package.json
@@ -60,7 +60,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
-    "@contentful/rich-text-types": "^5.0.0",
+    "@contentful/rich-text-types": "^15.7.0",
     "lodash.flatmap": "^4.5.0",
     "lodash.get": "^4.4.2",
     "lodash.omit": "^4.5.0"

--- a/packages/contentful-slatejs-adapter/src/__test__/contentful-helpers.ts
+++ b/packages/contentful-slatejs-adapter/src/__test__/contentful-helpers.ts
@@ -1,22 +1,34 @@
-import * as Contentful from '@contentful/rich-text-types';
+import {
+  BLOCKS,
+  INLINES,
+  Document,
+  Block,
+  Inline,
+  Text,
+  Mark,
+  TopLevelBlock,
+  TopLevelBlockEnum,
+} from '@contentful/rich-text-types';
 
 export interface NodeProps {
   isVoid?: boolean;
   data?: Record<string, any>;
 }
 
-export function document(...content: Contentful.Block[]): Contentful.Document {
+export function document(...content: TopLevelBlock[]): Document {
   return {
     data: {},
-    nodeType: Contentful.BLOCKS.DOCUMENT,
+    nodeType: BLOCKS.DOCUMENT,
     content,
   };
 }
 
 export function block(
-  nodeType: string,
-  ...content: Array<Contentful.Block | Contentful.Inline | Contentful.Text>
-): Contentful.Block {
+  nodeType: TopLevelBlockEnum,
+  ...content: Array<Block | Inline | Text>
+): TopLevelBlock;
+export function block(nodeType: BLOCKS, ...content: Array<Block | Inline | Text>): Block;
+export function block(nodeType: BLOCKS, ...content: Array<Block | Inline | Text>): Block {
   return {
     nodeType,
     content,
@@ -24,10 +36,7 @@ export function block(
   };
 }
 
-export function inline(
-  nodeType: string,
-  ...content: Array<Contentful.Inline | Contentful.Text>
-): Contentful.Inline {
+export function inline(nodeType: INLINES, ...content: Array<Inline | Text>): Inline {
   return {
     nodeType,
     content,
@@ -35,7 +44,7 @@ export function inline(
   };
 }
 
-export function text(value: string, ...marks: Contentful.Mark[]): Contentful.Text {
+export function text(value: string, ...marks: Mark[]): Text {
   return {
     nodeType: 'text',
     data: {},
@@ -44,7 +53,7 @@ export function text(value: string, ...marks: Contentful.Mark[]): Contentful.Tex
   };
 }
 
-export function mark(type: string): Contentful.Mark {
+export function mark(type: string): Mark {
   return {
     type,
   };

--- a/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
+++ b/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
@@ -463,7 +463,7 @@ describe('toContentfulDocument() adapter (non-roundtrippable cases)', () => {
           content: [
             {
               nodeType: 'text',
-              marks: [],
+              marks: [] as any,
               data: {},
               value: '',
             },
@@ -484,12 +484,26 @@ describe('toContentfulDocument() adapter (non-roundtrippable cases)', () => {
         },
         {
           nodeType: Contentful.BLOCKS.PARAGRAPH,
-          content: [],
+          content: [
+            {
+              nodeType: 'text',
+              marks: [],
+              data: {},
+              value: '',
+            },
+          ],
           data: {},
         },
         {
           nodeType: Contentful.BLOCKS.HEADING_2,
-          content: [],
+          content: [
+            {
+              nodeType: 'text',
+              marks: [],
+              data: {},
+              value: '',
+            },
+          ],
           data: {},
         },
       ],

--- a/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
+++ b/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
@@ -211,7 +211,14 @@ describe('both adapters (roundtrippable cases)', () => {
         content: [
           {
             nodeType: Contentful.BLOCKS.PARAGRAPH,
-            content: [],
+            content: [
+              {
+                nodeType: 'text',
+                marks: [],
+                data: {},
+                value: '',
+              },
+            ],
             data: { a: 1 },
           },
         ],
@@ -221,7 +228,7 @@ describe('both adapters (roundtrippable cases)', () => {
           type: Contentful.BLOCKS.PARAGRAPH,
           data: { a: 1 },
           isVoid: false,
-          children: [],
+          children: [{ text: '', data: {} }],
         },
       ],
     );
@@ -363,6 +370,59 @@ describe('both adapters (roundtrippable cases)', () => {
       });
       expect(actualContentfulDoc).toEqual(contentfulDoc);
     });
+  });
+});
+
+describe('toSlatejsDocument() adapter (non-roundtrippable cases)', () => {
+  // `content` for any TEXT_CONTAINER contentful node could be empty according to our
+  // validation rules, but SlateJS could crash if there isn't a text leaf.
+  it('inserts empty text nodes into text container blocks with empty `content`', () => {
+    const cfDoc = {
+      nodeType: Contentful.BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: Contentful.BLOCKS.PARAGRAPH,
+          content: [] as any,
+          data: {},
+        },
+        {
+          nodeType: Contentful.BLOCKS.HEADING_1,
+          content: [] as any,
+          data: {},
+        },
+        {
+          nodeType: Contentful.BLOCKS.HEADING_6,
+          content: [] as any,
+          data: { a: 42 },
+        },
+      ],
+    };
+    const expectedSlateDoc = [
+      {
+        type: Contentful.BLOCKS.PARAGRAPH,
+        data: {},
+        isVoid: false,
+        children: [{ text: '', data: {} }],
+      },
+      {
+        type: Contentful.BLOCKS.HEADING_1,
+        data: {},
+        isVoid: false,
+        children: [{ text: '', data: {} }],
+      },
+      {
+        type: Contentful.BLOCKS.HEADING_6,
+        data: { a: 42 },
+        isVoid: false,
+        children: [{ text: '', data: {} }],
+      },
+    ];
+    const actualSlateDoc = toSlatejsDocument({
+      document: cfDoc,
+      schema,
+    });
+    expect(actualSlateDoc).toEqual(expectedSlateDoc);
   });
 });
 

--- a/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
+++ b/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
@@ -397,7 +397,7 @@ describe('toSlatejsDocument() adapter (non-roundtrippable cases)', () => {
           data: { a: 42 },
         },
       ],
-    };
+    } as Contentful.Document;
     const expectedSlateDoc = [
       {
         type: Contentful.BLOCKS.PARAGRAPH,
@@ -426,7 +426,7 @@ describe('toSlatejsDocument() adapter (non-roundtrippable cases)', () => {
   });
 });
 
-describe('toContentfulDocument() adapter (non-roundtrippable cases)', () => {
+describe('toContentfulDocument()}; adapter (non-roundtrippable cases)', () => {
   it('neither inserts nor removes empty text nodes on container blocks with empty `children`', () => {
     const slateDoc = [
       {

--- a/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
+++ b/packages/contentful-slatejs-adapter/src/__test__/contentful-to-slatejs-adapter.test.ts
@@ -7,7 +7,7 @@ import { SlateNode } from '../types';
 
 const schema = { blocks: { [Contentful.BLOCKS.EMBEDDED_ENTRY]: { isVoid: true } } };
 
-describe('adapters', () => {
+describe('both adapters (roundtrippable cases)', () => {
   const testAdapters = (
     message: string,
     contentfulDoc: Contentful.Document,
@@ -73,9 +73,9 @@ describe('adapters', () => {
               data: {},
               isVoid: false,
               children: [],
-            }
-          ]
-        }
+            },
+          ],
+        },
       ],
     );
 
@@ -87,10 +87,8 @@ describe('adapters', () => {
           type: Contentful.BLOCKS.PARAGRAPH,
           data: {},
           isVoid: false,
-          children: [
-            { text: 'hi', data: {} }
-          ]
-        }
+          children: [{ text: 'hi', data: {} }],
+        },
       ],
     );
 
@@ -122,10 +120,8 @@ describe('adapters', () => {
           type: Contentful.BLOCKS.PARAGRAPH,
           data: {},
           isVoid: false,
-          children: [
-            { text: 'Hi', data: {} }
-          ]
-        }
+          children: [{ text: 'Hi', data: {} }],
+        },
       ];
       const ctflDoc = toContentfulDocument({
         document: slateDoc,
@@ -198,9 +194,7 @@ describe('adapters', () => {
               type: Contentful.BLOCKS.PARAGRAPH,
               data: {},
               isVoid: false,
-              children: [
-                { text: 'this is it', data: {} },
-              ],
+              children: [{ text: 'this is it', data: {} }],
             },
           ],
         },
@@ -359,9 +353,7 @@ describe('adapters', () => {
           type: Contentful.BLOCKS.EMBEDDED_ENTRY,
           data: { a: 1 },
           isVoid: true,
-          children: [
-            { text: '', data: {} },
-          ]
+          children: [{ text: '', data: {} }],
         },
       ];
 
@@ -371,5 +363,81 @@ describe('adapters', () => {
       });
       expect(actualContentfulDoc).toEqual(contentfulDoc);
     });
+  });
+});
+
+describe('toContentfulDocument() adapter (non-roundtrippable cases)', () => {
+  it('neither inserts nor removes empty text nodes on container blocks with empty `children`', () => {
+    const slateDoc = [
+      {
+        type: Contentful.BLOCKS.HEADING_1,
+        data: {},
+        isVoid: false,
+        children: [{ text: '', data: {} }],
+      },
+      {
+        type: Contentful.BLOCKS.PARAGRAPH,
+        data: {},
+        isVoid: false,
+        children: [{ text: '', data: {} }],
+      },
+      {
+        type: Contentful.BLOCKS.PARAGRAPH,
+        data: {},
+        isVoid: false,
+        children: [],
+      },
+      {
+        type: Contentful.BLOCKS.HEADING_2,
+        data: {},
+        isVoid: false,
+        children: [],
+      },
+    ];
+    const expectedCfDoc = {
+      nodeType: Contentful.BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: Contentful.BLOCKS.HEADING_1,
+          content: [
+            {
+              nodeType: 'text',
+              marks: [],
+              data: {},
+              value: '',
+            },
+          ],
+          data: {},
+        },
+        {
+          nodeType: Contentful.BLOCKS.PARAGRAPH,
+          content: [
+            {
+              nodeType: 'text',
+              marks: [],
+              data: {},
+              value: '',
+            },
+          ],
+          data: {},
+        },
+        {
+          nodeType: Contentful.BLOCKS.PARAGRAPH,
+          content: [],
+          data: {},
+        },
+        {
+          nodeType: Contentful.BLOCKS.HEADING_2,
+          content: [],
+          data: {},
+        },
+      ],
+    };
+    const actualCfDoc = toContentfulDocument({
+      document: slateDoc,
+      schema,
+    });
+    expect(actualCfDoc).toEqual(expectedCfDoc);
   });
 });

--- a/packages/contentful-slatejs-adapter/src/contentful-to-slatejs-adapter.ts
+++ b/packages/contentful-slatejs-adapter/src/contentful-to-slatejs-adapter.ts
@@ -42,9 +42,13 @@ function convertNode(node: ContentfulNode, schema: Schema): SlateNode {
 
 function convertElementNode(
   contentfulBlock: ContentfulElementNode,
-  children: SlateNode[],
+  slateChildren: SlateNode[],
   schema: Schema,
 ): SlateElement {
+  const children =
+    slateChildren.length === 0 && schema.isTextContainer(contentfulBlock.nodeType)
+      ? [{ text: '', data: {} }]
+      : slateChildren;
   return {
     type: contentfulBlock.nodeType,
     children,
@@ -57,7 +61,7 @@ function convertTextNode(node: Contentful.Text): SlateText {
   return {
     text: node.value,
     data: getDataOrDefault(node.data),
-    ...convertTextMarks(node)
+    ...convertTextMarks(node),
   };
 }
 

--- a/packages/contentful-slatejs-adapter/src/schema.ts
+++ b/packages/contentful-slatejs-adapter/src/schema.ts
@@ -48,11 +48,11 @@ export function fromJSON(schema: SchemaJSON = defaultSchema): Schema {
      * @returns
      */
     isVoid(node: ContentfulElementNode) {
-      const root = Object.values(BLOCKS).includes(node.nodeType) ? 'blocks' : 'inlines';
+      const root = Object.values(BLOCKS).includes(node.nodeType as any) ? 'blocks' : 'inlines';
       return get(schema, [root, node.nodeType as string, 'isVoid'], false);
     },
     isTextContainer(nodeType: string) {
-      return TEXT_CONTAINERS.includes(nodeType);
+      return TEXT_CONTAINERS.includes(nodeType as any);
     },
   };
 }

--- a/packages/contentful-slatejs-adapter/src/schema.ts
+++ b/packages/contentful-slatejs-adapter/src/schema.ts
@@ -1,9 +1,15 @@
 import get from 'lodash.get';
-import * as Contentful from '@contentful/rich-text-types';
+import { BLOCKS, TEXT_CONTAINERS } from '@contentful/rich-text-types';
 import { ContentfulElementNode } from './types';
 
 const defaultSchema: SchemaJSON = {};
 
+// TODO: Get rid of outdated SlateJS schema concept here and instead construct
+//  a `Schema` object based on `rich-text-types` constants. The original idea
+//  was to decouple code from these constants for future extensibility cases
+//  where we had to deal with custom node types that wouldn't be part of these
+//  constants while a custom (forked) rich-text editor provided `Schema`
+//  instance would be aware of them.
 /**
  * SlateJS Schema definition v0.33.x
  *
@@ -14,8 +20,10 @@ export interface SchemaJSON {
   blocks?: Record<string, SchemaValue>;
   inlines?: Record<string, SchemaValue>;
 }
+// TODO: No need to extend `SchemaJSON` and change `isVoid` to take a `nodeType: string`
 export interface Schema extends SchemaJSON {
   isVoid(node: ContentfulElementNode): boolean;
+  isTextContainer(nodeType: string): boolean;
 }
 
 export interface SchemaValue {
@@ -40,8 +48,11 @@ export function fromJSON(schema: SchemaJSON = defaultSchema): Schema {
      * @returns
      */
     isVoid(node: ContentfulElementNode) {
-      const root = Object.values(Contentful.BLOCKS).includes(node.nodeType) ? 'blocks' : 'inlines';
+      const root = Object.values(BLOCKS).includes(node.nodeType) ? 'blocks' : 'inlines';
       return get(schema, [root, node.nodeType as string, 'isVoid'], false);
+    },
+    isTextContainer(nodeType: string) {
+      return TEXT_CONTAINERS.includes(nodeType);
     },
   };
 }

--- a/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
+++ b/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
@@ -28,17 +28,11 @@ export default function toContentfulDocument({
   return {
     nodeType: Contentful.BLOCKS.DOCUMENT,
     data: {},
-    content: flatMap(
-      document,
-      node => convertNode(node, fromJSON(schema)) as Contentful.Block[],
-    ),
+    content: flatMap(document, node => convertNode(node, fromJSON(schema)) as Contentful.Block[]),
   };
 }
 
-function convertNode(
-  node: SlateNode,
-  schema: Schema
-): ContentfulNode[] {
+function convertNode(node: SlateNode, schema: Schema): ContentfulNode[] {
   const nodes: ContentfulNode[] = [];
   if (isSlateElement(node)) {
     const contentfulElement: ContentfulElementNode = {
@@ -47,7 +41,9 @@ function convertNode(
       content: [],
     };
     if (!schema.isVoid(contentfulElement)) {
-      contentfulElement.content = flatMap(node.children, childNode => convertNode(childNode, schema));
+      contentfulElement.content = flatMap(node.children, childNode =>
+        convertNode(childNode, schema),
+      );
     }
     nodes.push(contentfulElement);
   } else {

--- a/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
+++ b/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
@@ -28,7 +28,10 @@ export default function toContentfulDocument({
   return {
     nodeType: Contentful.BLOCKS.DOCUMENT,
     data: {},
-    content: flatMap(document, node => convertNode(node, fromJSON(schema)) as Contentful.Block[]),
+    content: flatMap(
+      document,
+      node => convertNode(node, fromJSON(schema)) as Contentful.TopLevelBlock[],
+    ),
   };
 }
 
@@ -36,7 +39,7 @@ function convertNode(node: SlateNode, schema: Schema): ContentfulNode[] {
   const nodes: ContentfulNode[] = [];
   if (isSlateElement(node)) {
     const contentfulElement: ContentfulElementNode = {
-      nodeType: node.type,
+      nodeType: node.type as Contentful.BLOCKS,
       data: getDataOrDefault(node.data),
       content: [],
     };

--- a/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
+++ b/packages/contentful-slatejs-adapter/src/slatejs-to-contentful-adapter.ts
@@ -45,6 +45,9 @@ function convertNode(node: SlateNode, schema: Schema): ContentfulNode[] {
         convertNode(childNode, schema),
       );
     }
+    if (contentfulElement.content.length === 0 && schema.isTextContainer(node.type)) {
+      contentfulElement.content.push(convertText({ text: '', data: {} }));
+    }
     nodes.push(contentfulElement);
   } else {
     const contentfulText = convertText(node);

--- a/packages/rich-text-html-renderer/package-lock.json
+++ b/packages/rich-text-html-renderer/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.6.2",
+			"version": "15.7.0",
 			"license": "MIT",
 			"devDependencies": {
 				"rollup-plugin-node-resolve": "^4.2.3"


### PR DESCRIPTION
Depends on change in #286

`content` for any `TEXT_CONTAINER` contentful node could be empty according to our CMA validation rules, but we want consistent handling, even if we upgrade to a future SlateJS versions that might introduce different handling like not always inserting empty text leaves.

With this change we ensure that:
1. The output contentful document's block nodes' `content` always includes at least an empty text node, unless it's a node type supposed to be void or supposed to contain other block nodes.
2. The output SlateJS document's block nodes' `children` always includes at least an empty text node, unless it's a node type supposed to be void or supposed to contain other block nodes.