### PR TITLE
test: add inline embeds in table to links test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35862,7 +35862,7 @@
 		},
 		"packages/contentful-slatejs-adapter": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.7.0",
+			"version": "15.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@contentful/rich-text-types": "^15.7.0",
@@ -36233,7 +36233,7 @@
 		},
 		"packages/rich-text-html-renderer": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.7.0",
+			"version": "15.8.0",
 			"license": "MIT",
 			"dependencies": {
 				"@contentful/rich-text-types": "^15.7.0",

--- a/packages/contentful-slatejs-adapter/package-lock.json
+++ b/packages/contentful-slatejs-adapter/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.7.0",
+			"version": "15.8.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^10.0.3",

--- a/packages/rich-text-html-renderer/package-lock.json
+++ b/packages/rich-text-html-renderer/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.7.0",
+			"version": "15.8.0",
 			"license": "MIT",
 			"devDependencies": {
 				"rollup-plugin-node-resolve": "^4.2.3"

--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -212,10 +212,10 @@ describe('getRichTextEntityLinks', () => {
                       data: {},
                       content: [
                         {
-                          nodeType: INLINES.EMBEDDED_ENTRY,
+                          nodeType: INLINES.ENTRY_HYPERLINK,
                           data: {
                             target: {
-                              sys: { id: 'inline-cell-entry', type: 'Link', linkType: 'Entry' },
+                              sys: { id: 'hyperlink-cell-entry', type: 'Link', linkType: 'Entry' },
                             },
                           },
                           content: [],
@@ -227,7 +227,33 @@ describe('getRichTextEntityLinks', () => {
                 {
                   nodeType: BLOCKS.TABLE_CELL,
                   data: {},
-                  content: [{ data: {}, content: [], nodeType: BLOCKS.PARAGRAPH }],
+                  content: [
+                    {
+                      data: {},
+                      content: [
+                        {
+                          nodeType: BLOCKS.PARAGRAPH,
+                          data: {},
+                          content: [
+                            {
+                              nodeType: INLINES.ASSET_HYPERLINK,
+                              data: {
+                                target: {
+                                  sys: {
+                                    id: 'hyperlink-cell-asset',
+                                    type: 'Link',
+                                    linkType: 'Asset',
+                                  },
+                                },
+                              },
+                              content: [],
+                            },
+                          ],
+                        },
+                      ],
+                      nodeType: BLOCKS.PARAGRAPH,
+                    },
+                  ],
                 },
               ],
             },
@@ -257,7 +283,7 @@ describe('getRichTextEntityLinks', () => {
           {
             linkType: 'Entry',
             type: 'Link',
-            id: 'inline-cell-entry',
+            id: 'hyperlink-cell-entry',
           },
           {
             linkType: 'Entry',
@@ -275,6 +301,11 @@ describe('getRichTextEntityLinks', () => {
             linkType: 'Asset',
             type: 'Link',
             id: 'quux',
+          },
+          {
+            linkType: 'Asset',
+            type: 'Link',
+            id: 'hyperlink-cell-asset',
           },
         ],
       });

--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -163,6 +163,76 @@ describe('getRichTextEntityLinks', () => {
             },
           ],
         },
+        {
+          nodeType: BLOCKS.TABLE,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.TABLE_ROW,
+              data: {},
+              content: [
+                {
+                  nodeType: BLOCKS.TABLE_HEADER_CELL,
+                  data: {},
+                  content: [{ data: {}, content: [], nodeType: BLOCKS.PARAGRAPH }],
+                },
+                {
+                  nodeType: BLOCKS.TABLE_HEADER_CELL,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.PARAGRAPH,
+                      data: {},
+                      content: [
+                        {
+                          nodeType: INLINES.EMBEDDED_ENTRY,
+                          data: {
+                            target: {
+                              sys: { id: 'inline-header-entry', type: 'Link', linkType: 'Entry' },
+                            },
+                          },
+                          content: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              nodeType: BLOCKS.TABLE_ROW,
+              data: {},
+              content: [
+                {
+                  nodeType: BLOCKS.TABLE_CELL,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.PARAGRAPH,
+                      data: {},
+                      content: [
+                        {
+                          nodeType: INLINES.EMBEDDED_ENTRY,
+                          data: {
+                            target: {
+                              sys: { id: 'inline-cell-entry', type: 'Link', linkType: 'Entry' },
+                            },
+                          },
+                          content: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: BLOCKS.TABLE_CELL,
+                  data: {},
+                  content: [{ data: {}, content: [], nodeType: BLOCKS.PARAGRAPH }],
+                },
+              ],
+            },
+          ],
+        },
       ],
     };
 
@@ -183,6 +253,16 @@ describe('getRichTextEntityLinks', () => {
             linkType: 'Entry',
             type: 'Link',
             id: 'bar',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'inline-cell-entry',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'inline-header-entry',
           },
         ],
         Asset: [


### PR DESCRIPTION
Adds table node with inline embeds in a header/cell to the links resolving test.