### PR TITLE
fix(rich-text-types): resolve generated JSON schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
 				"@types/rollup-plugin-json": "^3.0.3",
 				"ajv": "^8.8.2",
 				"colors": "^1.1.2",
-				"core-js": "^3.17.2",
 				"coveralls": "^3.0.0",
 				"cross-env": "^5.0.1",
 				"cz-conventional-changelog": "^2.0.0",
@@ -10186,6 +10185,7 @@
 			"version": "3.19.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
 			"integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
 				"type": "opencollective",
@@ -36137,10 +36137,10 @@
 		},
 		"packages/contentful-slatejs-adapter": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.8.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"lodash.flatmap": "^4.5.0",
 				"lodash.get": "^4.4.2",
 				"lodash.omit": "^4.5.0"
@@ -36481,10 +36481,10 @@
 		},
 		"packages/rich-text-from-markdown": {
 			"name": "@contentful/rich-text-from-markdown",
-			"version": "15.7.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"lodash": "^4.17.11",
 				"remark-parse": "^6.0.3",
 				"unified": "^7.1.0"
@@ -36508,10 +36508,10 @@
 		},
 		"packages/rich-text-html-renderer": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.8.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"escape-html": "^1.0.3"
 			},
 			"devDependencies": {
@@ -36536,10 +36536,10 @@
 		},
 		"packages/rich-text-links": {
 			"name": "@contentful/rich-text-links",
-			"version": "15.7.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0"
+				"@contentful/rich-text-types": "^15.9.0"
 			},
 			"devDependencies": {
 				"jest": "^27.1.0",
@@ -36560,10 +36560,10 @@
 		},
 		"packages/rich-text-plain-text-renderer": {
 			"name": "@contentful/rich-text-plain-text-renderer",
-			"version": "15.7.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0"
+				"@contentful/rich-text-types": "^15.9.0"
 			},
 			"devDependencies": {
 				"jest": "^27.1.0",
@@ -36584,10 +36584,10 @@
 		},
 		"packages/rich-text-react-renderer": {
 			"name": "@contentful/rich-text-react-renderer",
-			"version": "15.7.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
-				"@contentful/rich-text-types": "^15.7.0"
+				"@contentful/rich-text-types": "^15.9.0"
 			},
 			"devDependencies": {
 				"@types/react": "^16.8.15",
@@ -36616,7 +36616,7 @@
 		},
 		"packages/rich-text-types": {
 			"name": "@contentful/rich-text-types",
-			"version": "15.7.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"dependencies": {
 				"ajv": "^8.8.2"
@@ -36624,7 +36624,6 @@
 			"devDependencies": {
 				"@types/jest": "^27.0.1",
 				"@types/node": "^14.17.14",
-				"core-js": "^3.17.2",
 				"faker": "^4.1.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
@@ -38067,7 +38066,7 @@
 		"@contentful/contentful-slatejs-adapter": {
 			"version": "file:packages/contentful-slatejs-adapter",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"@types/jest": "^27.0.1",
 				"@types/lodash.flatmap": "^4.5.3",
 				"@types/lodash.get": "^4.4.4",
@@ -38352,7 +38351,7 @@
 		"@contentful/rich-text-from-markdown": {
 			"version": "file:packages/rich-text-from-markdown",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"@types/lodash": "^4.14.172",
 				"faker": "^4.1.0",
 				"jest": "^27.1.0",
@@ -38375,7 +38374,7 @@
 		"@contentful/rich-text-html-renderer": {
 			"version": "file:packages/rich-text-html-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"@types/escape-html": "^0.0.20",
 				"@types/lodash.clonedeep": "^4.5.6",
 				"escape-html": "^1.0.3",
@@ -38396,7 +38395,7 @@
 		"@contentful/rich-text-links": {
 			"version": "file:packages/rich-text-links",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
 				"rollup": "^1.32.1",
@@ -38413,7 +38412,7 @@
 		"@contentful/rich-text-plain-text-renderer": {
 			"version": "file:packages/rich-text-plain-text-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
 				"rollup": "^1.32.1",
@@ -38430,7 +38429,7 @@
 		"@contentful/rich-text-react-renderer": {
 			"version": "file:packages/rich-text-react-renderer",
 			"requires": {
-				"@contentful/rich-text-types": "^15.7.0",
+				"@contentful/rich-text-types": "^15.9.0",
 				"@types/react": "^16.8.15",
 				"@types/react-dom": "^16.8.4",
 				"jest": "^27.1.0",
@@ -38454,7 +38453,6 @@
 				"@types/jest": "^27.0.1",
 				"@types/node": "^14.17.14",
 				"ajv": "^8.8.2",
-				"core-js": "^3.17.2",
 				"faker": "^4.1.0",
 				"jest": "^27.1.0",
 				"rimraf": "^2.6.3",
@@ -45167,7 +45165,8 @@
 		"core-js": {
 			"version": "3.19.1",
 			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.19.1.tgz",
-			"integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg=="
+			"integrity": "sha512-Tnc7E9iKd/b/ff7GFbhwPVzJzPztGrChB8X8GLqoYGdEOG8IpLnK1xPyo3ZoO3HsK6TodJS58VGPOxA+hLHQMg==",
+			"dev": true
 		},
 		"core-js-compat": {
 			"version": "3.19.1",

--- a/packages/contentful-slatejs-adapter/package-lock.json
+++ b/packages/contentful-slatejs-adapter/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/contentful-slatejs-adapter",
-			"version": "15.8.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^10.0.3",

--- a/packages/rich-text-html-renderer/package-lock.json
+++ b/packages/rich-text-html-renderer/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@contentful/rich-text-html-renderer",
-			"version": "15.8.0",
+			"version": "15.9.0",
 			"license": "MIT",
 			"devDependencies": {
 				"rollup-plugin-node-resolve": "^4.2.3"

--- a/packages/rich-text-types/package.json
+++ b/packages/rich-text-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@contentful/rich-text-types",
   "version": "15.9.0",
-  "main": "dist/rich-text-types.es5.js",
+  "main": "dist/index.js",
   "typings": "dist/types/index.d.ts",
   "files": [
     "dist"

--- a/packages/rich-text-types/package.json
+++ b/packages/rich-text-types/package.json
@@ -30,7 +30,6 @@
   "devDependencies": {
     "@types/jest": "^27.0.1",
     "@types/node": "^14.17.14",
-    "core-js": "^3.17.2",
     "faker": "^4.1.0",
     "jest": "^27.1.0",
     "rimraf": "^2.6.3",

--- a/packages/rich-text-types/rollup.config.js
+++ b/packages/rich-text-types/rollup.config.js
@@ -8,11 +8,18 @@ const customConfig = () => {
 
   return {
     ...baseConfig,
+    output: {
+      // Maintain the same file names & folders structure as "src"
+      // This is necessary to resolve generated JSON schema files
+      //
+      // https://rollupjs.org/guide/en/#outputpreservemodules
+      preserveModules: true,
+    },
     plugins: [
       ...baseConfig.plugins,
       copy({
         targets: {
-          'src/schemas/generated': 'dist/lib/schemas/generated',
+          'src/schemas/generated': 'dist/schemas/generated',
         },
       }),
     ],

--- a/packages/rich-text-types/src/helpers.ts
+++ b/packages/rich-text-types/src/helpers.ts
@@ -3,17 +3,31 @@ import { BLOCKS } from './blocks';
 import { INLINES } from './inlines';
 
 /**
+ * Tiny replacement for Object.values(object).includes(key) to
+ * avoid including CoreJS polyfills
+ */
+function hasValue(obj: Record<string, unknown>, value: unknown) {
+  for (const key of Object.keys(obj)) {
+    if (value === obj[key]) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
  * Checks if the node is an instance of Inline.
  */
 export function isInline(node: Node): node is Inline {
-  return Object.values(INLINES).includes(node.nodeType as INLINES);
+  return hasValue(INLINES, node.nodeType);
 }
 
 /**
  * Checks if the node is an instance of Block.
  */
 export function isBlock(node: Node): node is Block {
-  return Object.values(BLOCKS).includes(node.nodeType as BLOCKS);
+  return hasValue(BLOCKS, node.nodeType);
 }
 
 /**

--- a/packages/rich-text-types/src/index.ts
+++ b/packages/rich-text-types/src/index.ts
@@ -1,6 +1,3 @@
-import 'core-js/features/object/values';
-import 'core-js/features/array/includes';
-
 export { BLOCKS } from './blocks';
 export { INLINES } from './inlines';
 export { default as MARKS } from './marks';

--- a/packages/rich-text-types/src/schemas/__test__/helpers.test.ts
+++ b/packages/rich-text-types/src/schemas/__test__/helpers.test.ts
@@ -1,0 +1,23 @@
+import { BLOCKS } from '../../blocks';
+import { INLINES } from '../../inlines';
+import { isBlock, isInline } from '../../helpers';
+
+test('isBlock', () => {
+  const block: any = { nodeType: BLOCKS.PARAGRAPH };
+  const nonBlock: any = { nodeType: 'Paragraph' };
+  const nonBlock2: any = { nodeType: undefined };
+
+  expect(isBlock(block)).toBe(true);
+  expect(isBlock(nonBlock)).toBe(false);
+  expect(isBlock(nonBlock2)).toBe(false);
+});
+
+test('isInline', () => {
+  const inline: any = { nodeType: INLINES.HYPERLINK };
+  const noninline: any = { nodeType: 'Hyperlink' };
+  const noninline2: any = { nodeType: undefined };
+
+  expect(isInline(inline)).toBe(true);
+  expect(isInline(noninline)).toBe(false);
+  expect(isInline(noninline2)).toBe(false);
+});

--- a/packages/rich-text-types/tsconfig.json
+++ b/packages/rich-text-types/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declarationDir": "dist/types",
-    "outDir": "dist/lib",
+    "outDir": "dist",
     "typeRoots": ["../../node_modules/@types", "node_modules/@types", "src/typings"],
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
Using the new `validateRichTextDocument` fails due to `require('./generated/{nodeType}.json')` unable to resolve the file.

**Before**:

```
dist/
  lib/
    schemas/
      generated/
      index.js // importing the helper directly works
  rich-text-types.es5.js // a single bundle of the whole source code. It fails to locate ./generated
```

**After**:

```
dist/
  schemas/
    generated/
    index.js // importing the helper directly still works
  index.js // now calls schemas/generated/index.js since the code no longer bundled together.
```