### PR TITLE
fix(react-renderer): wrap table rows in tbody

### DIFF
--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -226,30 +226,32 @@ Array [
 exports[`documentToReactComponents renders tables 1`] = `
 Array [
   <table>
-    <tr>
-      <td>
-        <p>
-          A 1
-        </p>
-      </td>
-      <td>
-        <p>
-          B 1
-        </p>
-      </td>
-    </tr>
-    <tr>
-      <td>
-        <p>
-          A 2
-        </p>
-      </td>
-      <td>
-        <p>
-          B 2
-        </p>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <td>
+          <p>
+            A 1
+          </p>
+        </td>
+        <td>
+          <p>
+            B 1
+          </p>
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <p>
+            A 2
+          </p>
+        </td>
+        <td>
+          <p>
+            B 2
+          </p>
+        </td>
+      </tr>
+    </tbody>
   </table>,
 ]
 `;
@@ -257,30 +259,32 @@ Array [
 exports[`documentToReactComponents renders tables with header 1`] = `
 Array [
   <table>
-    <tr>
-      <th>
-        <p>
-          A 1
-        </p>
-      </th>
-      <th>
-        <p>
-          B 1
-        </p>
-      </th>
-    </tr>
-    <tr>
-      <td>
-        <p>
-          A 2
-        </p>
-      </td>
-      <td>
-        <p>
-          B 2
-        </p>
-      </td>
-    </tr>
+    <tbody>
+      <tr>
+        <th>
+          <p>
+            A 1
+          </p>
+        </th>
+        <th>
+          <p>
+            B 1
+          </p>
+        </th>
+      </tr>
+      <tr>
+        <td>
+          <p>
+            A 2
+          </p>
+        </td>
+        <td>
+          <p>
+            B 2
+          </p>
+        </td>
+      </tr>
+    </tbody>
   </table>,
 ]
 `;

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -17,7 +17,11 @@ const defaultNodeRenderers: RenderNode = {
   [BLOCKS.LIST_ITEM]: (node, children) => <li>{children}</li>,
   [BLOCKS.QUOTE]: (node, children) => <blockquote>{children}</blockquote>,
   [BLOCKS.HR]: () => <hr />,
-  [BLOCKS.TABLE]: (node, children) => <table>{children}</table>,
+  [BLOCKS.TABLE]: (node, children) => (
+    <table>
+      <tbody>{children}</tbody>
+    </table>
+  ),
   [BLOCKS.TABLE_ROW]: (node, children) => <tr>{children}</tr>,
   [BLOCKS.TABLE_HEADER_CELL]: (node, children) => <th>{children}</th>,
   [BLOCKS.TABLE_CELL]: (node, children) => <td>{children}</td>,


### PR DESCRIPTION
Fixes the following warning:

```
Warning: validateDOMNesting(...): <tr> cannot appear as a child of <table>. Add a <tbody>, <thead> or <tfoot> to your code to match the DOM tree generated by the browser.
```