### PR TITLE
fix: add inline sources to packages

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "strict": true,
     "strictNullChecks": false,
     "sourceMap": true,
+    "inlineSources": true,
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
This is to fix the bug where source files are not included in the packages exported from this repo (namely `rich-text-types` was causing an issue in apps using rich-text). In order to match the `field-editors` package, it was decided that the source files should be built inline.