### PR TITLE
chore(deps): bump remark-parse from 6.0.3 to 10.0.1 in /packages/rich…

### DIFF
--- a/packages/rich-text-from-markdown/package.json
+++ b/packages/rich-text-from-markdown/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@contentful/rich-text-types": "^15.12.1",
     "lodash": "^4.17.11",
-    "remark-parse": "^6.0.3",
+    "remark-parse": "^10.0.1",
     "unified": "^7.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
bump remark-parse from 6.0.3 to 10.0.1 in /packages/rich-text-from-markdown