### PR TITLE
fix: remove the changes from the package-lock.json files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ jobs:
       - npm_install
       - run: npm run build
       - run: npm run lerna -- version --no-private --conventional-commits --create-release github --yes
+      # This to remove any generated package-lock.json files (this is the easiest solution to prevent breaking releases).
+      - run: git checkout .
       - run: npm run lerna -- publish from-git --yes
 
   compressed-size:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,8 @@ jobs:
       - npm_install
       - run: npm run build
       - run: npm run lerna -- version --no-private --conventional-commits --create-release github --yes
-      # This to remove any generated package-lock.json files (this is the easiest solution to prevent breaking releases).
+      # This is to remove any modifications that happened to the package-lock.json files,
+      # This is the easiest solution to prevent breaking releases
       - run: git checkout .
       - run: npm run lerna -- publish from-git --yes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,15 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add --no-package-lock ([#364](https://github.com/contentful/rich-text/issues/364)) ([41643c9](https://github.com/contentful/rich-text/commit/41643c9f61f525536941b54b64e944b70cb4a241))
-* add inline sources to packages ([#357](https://github.com/contentful/rich-text/issues/357)) ([bca6abb](https://github.com/contentful/rich-text/commit/bca6abb4328414b5a7a87b9b57481e161d800dcf))
-* add missing -- to circleci release commands ([#360](https://github.com/contentful/rich-text/issues/360)) ([233be08](https://github.com/contentful/rich-text/commit/233be0826cc7c76b799e70262b3281f7dbe4cd92))
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-* circleci update resource class ([#359](https://github.com/contentful/rich-text/issues/359)) ([6bb3710](https://github.com/contentful/rich-text/commit/6bb3710623907a2601c218f3cea3a817790cbf59))
-* revert change to monorepo tsconfig, apply to tsconfig in rich-text-types ([#358](https://github.com/contentful/rich-text/issues/358)) ([56126cc](https://github.com/contentful/rich-text/commit/56126cc9ed3704f21b89d2dbded160be0265f153))
-* update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
-
-
-
-
+- add --no-package-lock ([#364](https://github.com/contentful/rich-text/issues/364)) ([41643c9](https://github.com/contentful/rich-text/commit/41643c9f61f525536941b54b64e944b70cb4a241))
+- add inline sources to packages ([#357](https://github.com/contentful/rich-text/issues/357)) ([bca6abb](https://github.com/contentful/rich-text/commit/bca6abb4328414b5a7a87b9b57481e161d800dcf))
+- add missing -- to circleci release commands ([#360](https://github.com/contentful/rich-text/issues/360)) ([233be08](https://github.com/contentful/rich-text/commit/233be0826cc7c76b799e70262b3281f7dbe4cd92))
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
+- circleci update resource class ([#359](https://github.com/contentful/rich-text/issues/359)) ([6bb3710](https://github.com/contentful/rich-text/commit/6bb3710623907a2601c218f3cea3a817790cbf59))
+- revert change to monorepo tsconfig, apply to tsconfig in rich-text-types ([#358](https://github.com/contentful/rich-text/issues/358)) ([56126cc](https://github.com/contentful/rich-text/commit/56126cc9ed3704f21b89d2dbded160be0265f153))
+- update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
 
 ## [15.13.1](https://github.com/contentful/rich-text/compare/v15.13.0...v15.13.1) (2022-05-10)
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "husky": "^2.7.0",
     "lerna": "^5.5.0",
     "lint-staged": "^8.2.1",
-    "prettier": "^1.19.1",
+    "prettier": "1.19.1",
     "rollup": "^1.32.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-json": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "husky": "^2.7.0",
     "lerna": "^5.5.0",
     "lint-staged": "^8.2.1",
-    "prettier": "1.19.1",
+    "prettier": "^1.19.1",
     "rollup": "^1.32.1",
     "rollup-plugin-commonjs": "^9.3.4",
     "rollup-plugin-json": "^4.0.0",

--- a/packages/contentful-slatejs-adapter/CHANGELOG.md
+++ b/packages/contentful-slatejs-adapter/CHANGELOG.md
@@ -5,15 +5,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-* update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
+- update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
 
 ## [15.13.1](https://github.com/contentful/rich-text/compare/v15.13.0...v15.13.1) (2022-05-10)
 

--- a/packages/rich-text-from-markdown/CHANGELOG.md
+++ b/packages/rich-text-from-markdown/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
 
 ## [15.13.1](https://github.com/contentful/rich-text/compare/v15.13.0...v15.13.1) (2022-05-10)
 

--- a/packages/rich-text-html-renderer/CHANGELOG.md
+++ b/packages/rich-text-html-renderer/CHANGELOG.md
@@ -5,15 +5,10 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-* update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
+- update Lerna, rollup in slatejs-adapter ([#366](https://github.com/contentful/rich-text/issues/366)) ([32448e3](https://github.com/contentful/rich-text/commit/32448e369ae2b76601dd81839e13c15432430d68))
 
 ## [15.13.1](https://github.com/contentful/rich-text/compare/v15.13.0...v15.13.1) (2022-05-10)
 

--- a/packages/rich-text-links/CHANGELOG.md
+++ b/packages/rich-text-links/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
 
 ## [15.12.1](https://github.com/contentful/rich-text/compare/v15.12.0...v15.12.1) (2022-04-21)
 

--- a/packages/rich-text-plain-text-renderer/CHANGELOG.md
+++ b/packages/rich-text-plain-text-renderer/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
 
 ## [15.12.1](https://github.com/contentful/rich-text/compare/v15.12.0...v15.12.1) (2022-04-21)
 

--- a/packages/rich-text-react-renderer/CHANGELOG.md
+++ b/packages/rich-text-react-renderer/CHANGELOG.md
@@ -5,14 +5,9 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
 
 ## [15.12.1](https://github.com/contentful/rich-text/compare/v15.12.0...v15.12.1) (2022-04-21)
 

--- a/packages/rich-text-types/CHANGELOG.md
+++ b/packages/rich-text-types/CHANGELOG.md
@@ -1,19 +1,14 @@
-# Change Log
+``# Change Log
 
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
 ## [15.13.2](https://github.com/contentful/rich-text/compare/v15.13.1...v15.13.2) (2022-09-07)
 
-
 ### Bug Fixes
 
-* add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
-* revert change to monorepo tsconfig, apply to tsconfig in rich-text-types ([#358](https://github.com/contentful/rich-text/issues/358)) ([56126cc](https://github.com/contentful/rich-text/commit/56126cc9ed3704f21b89d2dbded160be0265f153))
-
-
-
-
+- add prettier write command ([#345](https://github.com/contentful/rich-text/issues/345)) ([0edad4c](https://github.com/contentful/rich-text/commit/0edad4c3176cea85d56a55fc5f4072419d730c8a))
+- revert change to monorepo tsconfig, apply to tsconfig in rich-text-types ([#358](https://github.com/contentful/rich-text/issues/358)) ([56126cc](https://github.com/contentful/rich-text/commit/56126cc9ed3704f21b89d2dbded160be0265f153))
 
 ## [15.12.1](https://github.com/contentful/rich-text/compare/v15.12.0...v15.12.1) (2022-04-21)
 


### PR DESCRIPTION
A hacky way to remove the modifications that happen to the `package-lock.json` files [see example](https://app.circleci.com/pipelines/github/contentful/rich-text/111/workflows/5f5d8c05-f24b-4bf2-ab94-242090943bd1/jobs/308)