### PR TITLE
build(release): run npm publish directly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,12 @@ jobs:
       - yarn_install
       - run: yarn build
       - run: yarn lerna:version
-      - run: yarn lerna:publish
+      # `lerna publish` fails with 404 for some reason but as far as we are concerned
+      # `npm publish` does the same thing since all the versioning, changelog generation
+      # GitHub releases happen in the `lerna version` command.
+      # Using `npx` instead of `yarn` due to an issue with yarn not reading the token
+      # from .npmrc
+      - run: npx lerna exec -- npm publish
 
   compressed-size:
     executor: default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,12 @@ Project on GitHub](https://egghead.io/series/how-to-contribute-to-an-open-source
 
 ## Useful npm scripts
 
-- `npm run build` builds vendored files in the `dist` directory of each package
-- `npm run commit` runs git commits with [commitizen](http://commitizen.github.io/cz-cli/)
-- `npm run clean` removes any built files and `node_modules`
-- `npm run lint` runs our TypeScript linter on all `.ts` files in each package
-- `npm run test` runs unit tests for all packages
-- `npm run test:ci` runs unit tests in CI mode
-- `npm run test:watch` runs unit tests in "watch" mode (will refresh relevant
+- `yarn build` builds vendored files in the `dist` directory of each package
+- `yarn commit` runs git commits with [commitizen](http://commitizen.github.io/cz-cli/)
+- `yarn clean` removes any built files and `node_modules`
+- `yarn lint` runs our TypeScript linter on all `.ts` files in each package
+- `yarn test` runs unit tests for all packages
+- `yarn test:watch` runs unit tests in "watch" mode (will refresh relevant
   code paths on save)
 
 ## Setup
@@ -60,7 +59,7 @@ compiled to ES5 using [rollup](https://rollupjs.org/guide/en) to the `dist`
 directory.
 
 This should generally only happen at publishing time, but you may want to run
-`npm run build` prematurely during local development.
+`yarn build` prematurely during local development.
 
 For example, let's say you're working on a pull request that
 
@@ -68,7 +67,7 @@ For example, let's say you're working on a pull request that
 2. adds behavior to handle that type in `rich-text-html-renderer`.
 
 If changes in the latter are dependent upon changes in the former, you'll need
-to run `npm run build` to update the referenced vendored files in
+to run `yarn build` to update the referenced vendored files in
 `rich-text-html-renderer`.
 
 All necessary dependencies are installed under `node_modules` and any necessary
@@ -79,7 +78,7 @@ globally.
 
 We follow [Angular JS Commit Message Conventions](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#allowed-type)
 to generate a changelog, enforced by [commitizen](http://commitizen.github.io/cz-cli/).
-You'll need to use `npm run commit` to create conventional commits.
+You'll need to use `yarn commit` to create conventional commits.
 
 ### Code style
 
@@ -112,13 +111,13 @@ To run all benchmarks for a particular package, e.g. `rich-text-links`, you
 can run the npm `benchmark` script scoped to that package:
 
 ```sh
-npm run benchmark @contentful/rich-text-links
+yarn benchmark @contentful/rich-text-links
 ```
 
 or
 
 ```sh
-npm run benchmark rich-text-links
+yarn benchmark rich-text-links
 ```
 
 Before submitting a pull request for a package with benchmarked code paths,
@@ -132,6 +131,6 @@ We use [Lerna](https://github.com/lerna/lerna) to:
 - keep dependencies in sync
   - `lerna bootstrap --hoist` (which is run as a post-install step)
 - publish
-  - `NPM_CONFIG_OTP={2fa_otp_goes_here} npm run publish`
+  - `NPM_CONFIG_OTP={2fa_otp_goes_here} yarn publish`
   - As a community developer, you most likely won't have to worry about this
     step :)

--- a/deprecated/gatsby-transformer-contentful-richtext/package.json
+++ b/deprecated/gatsby-transformer-contentful-richtext/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "babel src --out-dir . --ignore **/__tests__",
     "lint": "eslint --ext .js,.jsx packages/**/src integration-tests/**/src",
-    "prepare": "cross-env NODE_ENV=production npm run build",
+    "prepare": "cross-env NODE_ENV=production yarn build",
     "watch": "babel -w src --out-dir . --ignore **/__tests__"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx,md,mdx}'",
     "prebuild": "lerna run prebuild",
     "lerna:version": "lerna version --no-private --conventional-commits --create-release github --yes",
-    "lerna:publish": "npx lerna exec -- npm publish",
     "start": "lerna run start",
     "test": "lerna run test",
     "prepare": "husky install"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier:check": "prettier --check '**/*.{jsx,js,ts,tsx,md,mdx}'",
     "prebuild": "lerna run prebuild",
     "lerna:version": "lerna version --no-private --conventional-commits --create-release github --yes",
-    "lerna:publish": "lerna publish from-git --yes",
+    "lerna:publish": "npx lerna exec -- npm publish",
     "start": "lerna run start",
     "test": "lerna run test",
     "prepare": "husky install"
@@ -38,7 +38,7 @@
   "config": {
     "validate-commit-msg": {
       "types": "conventional-commit-types",
-      "helpMessage": "Use \"npm run commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
+      "helpMessage": "Use \"yarn commit\" instead, we use conventional-changelog format :) (https://github.com/commitizen/cz-cli)"
     },
     "commitizen": {
       "path": "./node_modules/git-cz"

--- a/packages/contentful-slatejs-adapter/package.json
+++ b/packages/contentful-slatejs-adapter/package.json
@@ -24,7 +24,7 @@
     "start": "rollup -c rollup.config.ts -w",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:prod": "npm run lint && npm run test -- --coverage --no-cache",
+    "test:prod": "yarn test -- --coverage --no-cache",
     "report-coverage": "cat ./coverage/lcov.info | coveralls"
   },
   "dependencies": {

--- a/packages/rich-text-types/package.json
+++ b/packages/rich-text-types/package.json
@@ -19,7 +19,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "npm run generate-json-schema && tsc --module commonjs && rollup -c rollup.config.js",
+    "build": "yarn generate-json-schema && tsc --module commonjs && rollup -c rollup.config.js",
     "start": "tsc && rollup -c rollup.config.js -w",
     "lint": "tslint -t codeFrame '@(src|bin)/*.ts'",
     "generate-json-schema": "ts-node -O '{\"module\": \"commonjs\"}' ./tools/jsonSchemaGen",


### PR DESCRIPTION
`lerna publish --from-git` fails with 404 error. This doesn't happen locally so it's hard to debug. While searching I noticed that we don't need lerna to publish since all the version bumping + changelog + GH release happens in the `lerna version` step.

So for our use case, `lerna publish` should be the same as running `npm publish` in all packages and that's what this PR is about to unblock publishing. 

Additionally I updated some READMEs to mention `yarn` instead of `npm run`.

This works locally but will have to wait for the CI 🤞🏻 