### PR TITLE
remove default export on MARKS to be ESM friendly

### DIFF
--- a/packages/rich-text-types/src/marks.ts
+++ b/packages/rich-text-types/src/marks.ts
@@ -1,7 +1,7 @@
 /**
  * Map of all Contentful marks.
  */
-enum MARKS {
+export enum MARKS {
   BOLD = 'bold',
   ITALIC = 'italic',
   UNDERLINE = 'underline',
@@ -9,5 +9,3 @@ enum MARKS {
   SUPERSCRIPT = 'superscript',
   SUBSCRIPT = 'subscript',
 }
-
-export default MARKS;


### PR DESCRIPTION
solves this issue https://github.com/contentful/rich-text/issues/395
with the same approach you are using for BLOCKS type 