### PR TITLE
fix: entrypoint for types of package [HOMER-1842]

### DIFF
--- a/packages/contentful-slatejs-adapter/package.json
+++ b/packages/contentful-slatejs-adapter/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "keywords": [],
   "main": "dist/contentful-slatejs-adapter.es5.js",
-  "typings": "dist/types/contentful-slatejs-adapter.d.ts",
+  "typings": "dist/types/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
When using this module somewhere else, we get TS errors due to missing exported types. It turned out that the `package.json` is pointing to a non-existing file.

<img width="493" alt="Screenshot 2023-03-30 at 15 45 48" src="https://user-images.githubusercontent.com/9327071/228856342-cc110bf3-3c6a-4355-bd45-ee907a8e6237.png">
