### PR TITLE
feat: add deduplicate option to getRichTextResourceLinks  [DANTE-1028]

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -719,4 +719,47 @@ describe(`getRichTextResourceLinks`, () => {
       makeResourceLink('space-1', 'entry-2'),
     ]);
   });
+
+  it(`should return duplicate links if the deduplicate option value is passed as false`, () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-2'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(
+      getRichTextResourceLinks(document, BLOCKS.EMBEDDED_RESOURCE, { deduplicate: false }),
+    ).toEqual([
+      makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-1', 'entry-2'),
+      makeResourceLink('space-1', 'entry-1'),
+    ]);
+  });
 });

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -29,6 +29,7 @@ type AcceptedResourceLinkTypes = `${BLOCKS.EMBEDDED_RESOURCE}`;
 export function getRichTextResourceLinks(
   document: Document,
   nodeType: AcceptedResourceLinkTypes,
+  { deduplicate = true }: { deduplicate?: boolean } = {},
 ): ResourceLink[] {
   const links = new Map<string, ResourceLink>();
   const isValidType = (actualNodeType: string, data: NodeData) =>
@@ -36,7 +37,8 @@ export function getRichTextResourceLinks(
 
   visitNodes(document, (node) => {
     if (isValidType(node.nodeType, node.data)) {
-      links.set(node.data.target.sys.urn, node.data.target);
+      const key = deduplicate ? node.data.target.sys.urn : links.size;
+      links.set(key, node.data.target);
     }
   });
 


### PR DESCRIPTION
This is needed to support use-cases where you are interested in the duplicate values of which we currently have two:
1. Counting the total amount of ResourceLink references or when generating a diff between the old and new entry state
2. Validating if a duplicate ResourceLink is added/removed (used for fencing)