### PR TITLE
feat: allow document parameter of getRichTextEntityLinks to be nullable []

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -1,5 +1,6 @@
 import { Document, BLOCKS, INLINES } from '@contentful/rich-text-types';
 import { getRichTextEntityLinks, getRichTextResourceLinks } from '../index';
+import { Maybe } from '../types/utils';
 
 function makeResourceLink(spaceId: string, entryId: string) {
   return {
@@ -77,9 +78,15 @@ describe('getRichTextEntityLinks', () => {
        * we know that not handling `null` gracefully will cause issues in production.
        */
 
-      const documentThatIsNull: Document | null = null;
+      const documentThatIsNull: Maybe<Document> = null;
 
-      expect(getRichTextEntityLinks(documentThatIsNull!)).toEqual({ Asset: [], Entry: [] });
+      expect(getRichTextEntityLinks(documentThatIsNull)).toEqual({ Asset: [], Entry: [] });
+    });
+
+    it('returns an empty array if document parameter is `undefined`', () => {
+      const documentThatIsUndefined: Maybe<Document> = undefined;
+
+      expect(getRichTextEntityLinks(documentThatIsUndefined)).toEqual({ Asset: [], Entry: [] });
     });
   });
 
@@ -527,9 +534,15 @@ describe(`getRichTextResourceLinks`, () => {
   });
 
   it('returns an empty array if document parameter is `null`', () => {
-    const document: Document | null = null;
+    const documentThatIsNull: Maybe<Document> = null;
 
-    expect(getRichTextResourceLinks(document!, BLOCKS.EMBEDDED_RESOURCE)).toEqual([]);
+    expect(getRichTextResourceLinks(documentThatIsNull, BLOCKS.EMBEDDED_RESOURCE)).toEqual([]);
+  });
+
+  it('returns an empty array if document parameter is `undefined`', () => {
+    const documentThatIsUndefined: Maybe<Document> = undefined;
+
+    expect(getRichTextResourceLinks(documentThatIsUndefined, BLOCKS.EMBEDDED_RESOURCE)).toEqual([]);
   });
 
   it(`returns all ResourceLinks from multiple levels in the same order as defined in the document`, () => {

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -8,6 +8,7 @@ import {
   NodeData,
   ResourceLink,
 } from '@contentful/rich-text-types';
+import { Maybe } from './types/utils';
 
 export type EntityLinks = { [type in EntityType]: EntityLink[] };
 export type EntityLinkMaps = { [type in EntityType]: Map<string, EntityLink> };
@@ -27,7 +28,7 @@ type AcceptedResourceLinkTypes = `${BLOCKS.EMBEDDED_RESOURCE}`;
  * Extracts all links no matter the entity they are pointing to.
  */
 export function getRichTextResourceLinks(
-  document: Document,
+  document: Maybe<Document>,
   nodeType: AcceptedResourceLinkTypes,
   { deduplicate = true }: { deduplicate?: boolean } = {},
 ): ResourceLink[] {
@@ -52,7 +53,7 @@ export function getRichTextEntityLinks(
   /**
    *  An instance of a Rich Text Document.
    */
-  document: Document,
+  document: Maybe<Document>,
   /**
    *  Node type. Only the entity links with given node type will be extracted.
    */
@@ -84,7 +85,7 @@ function isContentNode(node: Node): node is Inline | Block {
   return 'content' in node && Array.isArray(node.content);
 }
 
-function visitNodes(startNode: Node, onVisit: (node: Node) => void): void {
+function visitNodes(startNode: Maybe<Node>, onVisit: (node: Node) => void): void {
   /**
    * Do not remove this null check as consumers of this library do not all have good Typescript types
    */

--- a/packages/rich-text-links/src/types/utils.ts
+++ b/packages/rich-text-links/src/types/utils.ts
@@ -1,0 +1,1 @@
+export type Maybe<T> = T | null | undefined;


### PR DESCRIPTION
As an immediate action of [this postmortem](https://contentful.atlassian.net/wiki/spaces/ENG/pages/4240343365/2023-05-30+500+errors+on+entry+save+if+RichText+field+had+null+values) we decided to let the public type reflect the expected type that is passed to the function. 

This means that the type is now less strict which will make it clearer why we deliberately check for `null` values in our library code. This should cause this exact issue to not happen again (by accident) in the future.