### PR TITLE
feat: change visitNodes to visit nodes in depth-first order []

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -90,15 +90,7 @@ describe('getRichTextEntityLinks', () => {
       content: [
         {
           nodeType: BLOCKS.PARAGRAPH,
-          data: {
-            target: {
-              sys: {
-                linkType: 'Entry',
-                type: 'Link',
-                id: 'foo',
-              },
-            },
-          },
+          data: {},
           content: [
             {
               nodeType: BLOCKS.EMBEDDED_ENTRY,
@@ -283,23 +275,13 @@ describe('getRichTextEntityLinks', () => {
       ],
     };
 
-    it('returns all entity link objects', () => {
+    it('returns all entity link objects in the same order as defined in the document', () => {
       expect(getRichTextEntityLinks(document)).toEqual({
         Entry: [
           {
             linkType: 'Entry',
             type: 'Link',
-            id: 'hyperlink-cell-entry',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'inline-header-entry',
-          },
-          {
-            linkType: 'Entry',
-            type: 'Link',
-            id: 'foo',
+            id: 'bar',
           },
           {
             linkType: 'Entry',
@@ -309,14 +291,19 @@ describe('getRichTextEntityLinks', () => {
           {
             linkType: 'Entry',
             type: 'Link',
-            id: 'bar',
+            id: 'inline-header-entry',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'hyperlink-cell-entry',
           },
         ],
         Asset: [
           {
             linkType: 'Asset',
             type: 'Link',
-            id: 'hyperlink-cell-asset',
+            id: 'quux',
           },
           {
             linkType: 'Asset',
@@ -326,7 +313,7 @@ describe('getRichTextEntityLinks', () => {
           {
             linkType: 'Asset',
             type: 'Link',
-            id: 'quux',
+            id: 'hyperlink-cell-asset',
           },
         ],
       });
@@ -545,7 +532,7 @@ describe(`getRichTextResourceLinks`, () => {
     expect(getRichTextResourceLinks(document!, BLOCKS.EMBEDDED_RESOURCE)).toEqual([]);
   });
 
-  it(`returns resource-links from multiple levels`, () => {
+  it(`returns all ResourceLinks from multiple levels in the same order as defined in the document`, () => {
     const document: Document = {
       nodeType: BLOCKS.DOCUMENT,
       data: {},
@@ -672,11 +659,11 @@ describe(`getRichTextResourceLinks`, () => {
     };
 
     expect(getRichTextResourceLinks(document, BLOCKS.EMBEDDED_RESOURCE)).toEqual([
-      makeResourceLink('space-2', 'entry-3'),
-      makeResourceLink('space-2', 'entry-2'),
-      makeResourceLink('space-2', 'entry-1'),
-      makeResourceLink('space-1', 'entry-2'),
       makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-1', 'entry-2'),
+      makeResourceLink('space-2', 'entry-1'),
+      makeResourceLink('space-2', 'entry-2'),
+      makeResourceLink('space-2', 'entry-3'),
     ]);
   });
 

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -95,8 +95,8 @@ function visitNodes(startNode: Node, onVisit: (node: Node) => void): void {
     onVisit(node);
 
     if (isContentNode(node)) {
-      for (const childNode of node.content) {
-        toCrawl.push(childNode);
+      for (let i = node.content.length - 1; i >= 0; i--) {
+        toCrawl.push(node.content[i]);
       }
     }
   }


### PR DESCRIPTION
A customer opened a [zendesk ticket](https://contentful.atlassian.net/browse/ZEND-3701) to ask why the GraphQL API returns references in reverse order of how they are defined in the RichText document. 

This PR makes a slight change in how the stack is populated to make the depth-first search traverse nodes from top to bottom instead of from bottom to top. 