### PR TITLE
feat: add new nodes [DANTE-1157]

### DIFF
--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -1,5 +1,9 @@
 import { Document, BLOCKS, INLINES } from '@contentful/rich-text-types';
-import { getRichTextEntityLinks, getRichTextResourceLinks } from '../index';
+import {
+  getAllRichTextResourceLinks,
+  getRichTextEntityLinks,
+  getRichTextResourceLinks,
+} from '../index';
 import { Maybe } from '../types/utils';
 
 function makeResourceLink(spaceId: string, entryId: string) {
@@ -760,6 +764,325 @@ describe(`getRichTextResourceLinks`, () => {
       makeResourceLink('space-1', 'entry-1'),
       makeResourceLink('space-1', 'entry-2'),
       makeResourceLink('space-1', 'entry-1'),
+    ]);
+  });
+});
+
+describe(`getAllRichTextResourceLinks`, () => {
+  it('returns top-level rich text resource-links', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('foo', 'bar'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.RESOURCE_HYPERLINK,
+              data: {
+                target: makeResourceLink('foo2', 'bar'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('foo3', 'bar'),
+              },
+              content: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getAllRichTextResourceLinks(document)).toEqual([
+      makeResourceLink('foo', 'bar'),
+      makeResourceLink('foo2', 'bar'),
+      makeResourceLink('foo3', 'bar'),
+    ]);
+  });
+
+  it('returns an empty array if document parameter is `null`', () => {
+    const documentThatIsNull: Maybe<Document> = null;
+
+    expect(getAllRichTextResourceLinks(documentThatIsNull)).toEqual([]);
+  });
+
+  it('returns an empty array if document parameter is `undefined`', () => {
+    const documentThatIsUndefined: Maybe<Document> = undefined;
+
+    expect(getAllRichTextResourceLinks(documentThatIsUndefined)).toEqual([]);
+  });
+
+  it(`returns all ResourceLinks from multiple levels in the same order as defined in the document`, () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.OL_LIST,
+              data: {},
+              content: [
+                {
+                  nodeType: BLOCKS.LIST_ITEM,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.PARAGRAPH,
+                      data: {},
+                      content: [
+                        {
+                          nodeType: BLOCKS.LIST_ITEM,
+                          data: {},
+                          content: [
+                            {
+                              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+                              data: {
+                                target: makeResourceLink('space-1', 'entry-2'),
+                              },
+                              content: [],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  nodeType: BLOCKS.LIST_ITEM,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.EMBEDDED_RESOURCE,
+                      data: {
+                        target: makeResourceLink('space-2', 'entry-1'),
+                      },
+                      content: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.TABLE,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.TABLE_ROW,
+              data: {},
+              content: [
+                {
+                  nodeType: BLOCKS.TABLE_HEADER_CELL,
+                  data: {},
+                  content: [{ data: {}, content: [], nodeType: BLOCKS.PARAGRAPH }],
+                },
+                {
+                  nodeType: BLOCKS.TABLE_HEADER_CELL,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.PARAGRAPH,
+                      data: {},
+                      content: [
+                        {
+                          nodeType: BLOCKS.EMBEDDED_RESOURCE,
+                          data: {
+                            target: makeResourceLink('space-2', 'entry-2'),
+                          },
+                          content: [],
+                        },
+                        {
+                          nodeType: INLINES.RESOURCE_HYPERLINK,
+                          data: {
+                            target: makeResourceLink('space-2', 'entry'),
+                          },
+                          content: [],
+                        },
+                        {
+                          nodeType: INLINES.EMBEDDED_RESOURCE,
+                          data: {
+                            target: makeResourceLink('space-3', 'entry'),
+                          },
+                          content: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              nodeType: BLOCKS.TABLE_ROW,
+              data: {},
+              content: [
+                {
+                  nodeType: BLOCKS.TABLE_CELL,
+                  data: {},
+                  content: [
+                    {
+                      nodeType: BLOCKS.PARAGRAPH,
+                      data: {},
+                      content: [
+                        {
+                          nodeType: BLOCKS.EMBEDDED_RESOURCE,
+                          data: {
+                            target: makeResourceLink('space-2', 'entry-3'),
+                          },
+                          content: [],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    expect(getAllRichTextResourceLinks(document)).toEqual([
+      makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-1', 'entry-2'),
+      makeResourceLink('space-2', 'entry-1'),
+      makeResourceLink('space-2', 'entry-2'),
+      makeResourceLink('space-2', 'entry'),
+      makeResourceLink('space-3', 'entry'),
+      makeResourceLink('space-2', 'entry-3'),
+    ]);
+  });
+
+  it(`de-duplicates links based on urn`, () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-2'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-2', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.RESOURCE_HYPERLINK,
+              data: {
+                target: makeResourceLink('space-2', 'entry-1'),
+              },
+              content: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(getAllRichTextResourceLinks(document)).toEqual([
+      makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-1', 'entry-2'),
+      makeResourceLink('space-2', 'entry-1'),
+    ]);
+  });
+
+  it(`should return duplicate links if the deduplicate option value is passed as false`, () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-2'),
+              },
+              content: [],
+            },
+            {
+              nodeType: BLOCKS.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-1', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.EMBEDDED_RESOURCE,
+              data: {
+                target: makeResourceLink('space-2', 'entry-1'),
+              },
+              content: [],
+            },
+            {
+              nodeType: INLINES.RESOURCE_HYPERLINK,
+              data: {
+                target: makeResourceLink('space-2', 'entry-1'),
+              },
+              content: [],
+            },
+          ],
+        },
+      ],
+    };
+    expect(getAllRichTextResourceLinks(document, { deduplicate: false })).toEqual([
+      makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-1', 'entry-2'),
+      makeResourceLink('space-1', 'entry-1'),
+      makeResourceLink('space-2', 'entry-1'),
+      makeResourceLink('space-2', 'entry-1'),
     ]);
   });
 });

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -34,25 +34,16 @@ export function getRichTextResourceLinks(
   nodeType: AcceptedResourceLinkTypes,
   { deduplicate = true }: { deduplicate?: boolean } = {},
 ): ResourceLink[] {
-  const links = new Map<string, ResourceLink>();
   const isValidType = (actualNodeType: string, data: NodeData) =>
     actualNodeType === nodeType && data.target?.sys?.type === 'ResourceLink';
 
-  visitNodes(document, (node) => {
-    if (isValidType(node.nodeType, node.data)) {
-      const key = deduplicate ? node.data.target.sys.urn : links.size;
-      links.set(key, node.data.target);
-    }
-  });
-
-  return iteratorToArray(links.values());
+  return getValidResourceLinks(document, isValidType, deduplicate);
 }
 
 export function getAllRichTextResourceLinks(
   document: Maybe<Document>,
   { deduplicate = true }: { deduplicate?: boolean } = {},
 ): ResourceLink[] {
-  const links = new Map<string, ResourceLink>();
   const nodeTypes: string[] = [
     BLOCKS.EMBEDDED_RESOURCE,
     INLINES.EMBEDDED_RESOURCE,
@@ -61,6 +52,15 @@ export function getAllRichTextResourceLinks(
   const isValidType = (actualNodeType: string, data: NodeData) =>
     nodeTypes.includes(actualNodeType) && data.target?.sys?.type === 'ResourceLink';
 
+  return getValidResourceLinks(document, isValidType, deduplicate);
+}
+
+function getValidResourceLinks(
+  document: Maybe<Document>,
+  isValidType: (actualNodeType: string, data: NodeData) => boolean,
+  deduplicate: boolean,
+): ResourceLink[] {
+  const links = new Map<string, ResourceLink>();
   visitNodes(document, (node) => {
     if (isValidType(node.nodeType, node.data)) {
       const key = deduplicate ? node.data.target.sys.urn : links.size;

--- a/packages/rich-text-types/src/inlines.ts
+++ b/packages/rich-text-types/src/inlines.ts
@@ -5,7 +5,7 @@ export enum INLINES {
   HYPERLINK = 'hyperlink',
   ENTRY_HYPERLINK = 'entry-hyperlink',
   ASSET_HYPERLINK = 'asset-hyperlink',
-  // RESOURCE_HYPERLINK = 'resource-hyperlink',
+  RESOURCE_HYPERLINK = 'resource-hyperlink',
   EMBEDDED_ENTRY = 'embedded-entry-inline',
-  // EMBEDDED_RESOURCE = 'embedded-resource-inline',
+  EMBEDDED_RESOURCE = 'embedded-resource-inline',
 }

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -152,6 +152,18 @@ export interface EntryLinkInline extends Inline {
   content: Text[];
 }
 
+export interface ResourceLinkInline extends Inline {
+  nodeType: INLINES.EMBEDDED_RESOURCE;
+  data: {
+    target: Link<'Entry'>;
+  };
+  /**
+   *
+   * @maxItems 0
+   */
+  content: Text[];
+}
+
 export interface Hyperlink extends Inline {
   nodeType: INLINES.HYPERLINK;
   data: {
@@ -172,6 +184,14 @@ export interface EntryHyperlink extends Inline {
   nodeType: INLINES.ENTRY_HYPERLINK;
   data: {
     target: Link<'Entry'>;
+  };
+  content: Text[];
+}
+
+export interface ResourceHyperlink extends Inline {
+  nodeType: INLINES.RESOURCE_HYPERLINK;
+  data: {
+    target: ResourceLink;
   };
   content: Text[];
 }

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -155,7 +155,7 @@ export interface EntryLinkInline extends Inline {
 export interface ResourceLinkInline extends Inline {
   nodeType: INLINES.EMBEDDED_RESOURCE;
   data: {
-    target: Link<'Entry'>;
+    target: ResourceLink;
   };
   /**
    *

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -1174,41 +1174,6 @@ Object {
   "$ref": "#/definitions/ResourceLinkInline",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": Object {
-    "Link<\\"Entry\\">": Object {
-      "additionalProperties": false,
-      "properties": Object {
-        "sys": Object {
-          "additionalProperties": false,
-          "properties": Object {
-            "id": Object {
-              "type": "string",
-            },
-            "linkType": Object {
-              "enum": Array [
-                "Entry",
-              ],
-              "type": "string",
-            },
-            "type": Object {
-              "enum": Array [
-                "Link",
-              ],
-              "type": "string",
-            },
-          },
-          "required": Array [
-            "id",
-            "linkType",
-            "type",
-          ],
-          "type": "object",
-        },
-      },
-      "required": Array [
-        "sys",
-      ],
-      "type": "object",
-    },
     "Mark": Object {
       "additionalProperties": false,
       "properties": Object {
@@ -1225,6 +1190,41 @@ Object {
       "additionalProperties": true,
       "type": "object",
     },
+    "ResourceLink": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "sys": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "linkType": Object {
+              "enum": Array [
+                "Contentful:Entry",
+              ],
+              "type": "string",
+            },
+            "type": Object {
+              "enum": Array [
+                "ResourceLink",
+              ],
+              "type": "string",
+            },
+            "urn": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "linkType",
+            "type",
+            "urn",
+          ],
+          "type": "object",
+        },
+      },
+      "required": Array [
+        "sys",
+      ],
+      "type": "object",
+    },
     "ResourceLinkInline": Object {
       "additionalProperties": false,
       "properties": Object {
@@ -1239,7 +1239,7 @@ Object {
           "additionalProperties": false,
           "properties": Object {
             "target": Object {
-              "$ref": "#/definitions/Link<\\"Entry\\">",
+              "$ref": "#/definitions/ResourceLink",
             },
           },
           "required": Array [

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -135,8 +135,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -376,8 +378,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -567,8 +571,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -740,8 +746,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -996,8 +1004,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1114,6 +1124,132 @@ Object {
         "nodeType": Object {
           "enum": Array [
             "embedded-resource-block",
+          ],
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "Text": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "data": Object {
+          "$ref": "#/definitions/NodeData",
+        },
+        "marks": Object {
+          "items": Object {
+            "$ref": "#/definitions/Mark",
+          },
+          "type": "array",
+        },
+        "nodeType": Object {
+          "enum": Array [
+            "text",
+          ],
+          "type": "string",
+        },
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "data",
+        "marks",
+        "nodeType",
+        "value",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
+exports[`getSchemaWithNodeType returns json schema for each nodeType: embedded-resource-inline 1`] = `
+Object {
+  "$ref": "#/definitions/ResourceLinkInline",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": Object {
+    "Link<\\"Entry\\">": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "sys": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "id": Object {
+              "type": "string",
+            },
+            "linkType": Object {
+              "enum": Array [
+                "Entry",
+              ],
+              "type": "string",
+            },
+            "type": Object {
+              "enum": Array [
+                "Link",
+              ],
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "id",
+            "linkType",
+            "type",
+          ],
+          "type": "object",
+        },
+      },
+      "required": Array [
+        "sys",
+      ],
+      "type": "object",
+    },
+    "Mark": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "type": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "type",
+      ],
+      "type": "object",
+    },
+    "NodeData": Object {
+      "additionalProperties": true,
+      "type": "object",
+    },
+    "ResourceLinkInline": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "content": Object {
+          "items": Object {
+            "$ref": "#/definitions/Text",
+          },
+          "maxItems": 0,
+          "type": "array",
+        },
+        "data": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "target": Object {
+              "$ref": "#/definitions/Link<\\"Entry\\">",
+            },
+          },
+          "required": Array [
+            "target",
+          ],
+          "type": "object",
+        },
+        "nodeType": Object {
+          "enum": Array [
+            "embedded-resource-inline",
           ],
           "type": "string",
         },
@@ -1328,8 +1464,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1457,8 +1595,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1586,8 +1726,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1715,8 +1857,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1844,8 +1988,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -1973,8 +2119,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -2103,8 +2251,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -2347,8 +2497,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -2580,8 +2732,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -2781,8 +2935,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -2900,6 +3056,131 @@ Object {
 }
 `;
 
+exports[`getSchemaWithNodeType returns json schema for each nodeType: resource-hyperlink 1`] = `
+Object {
+  "$ref": "#/definitions/ResourceHyperlink",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": Object {
+    "Mark": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "type": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "type",
+      ],
+      "type": "object",
+    },
+    "NodeData": Object {
+      "additionalProperties": true,
+      "type": "object",
+    },
+    "ResourceHyperlink": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "content": Object {
+          "items": Object {
+            "$ref": "#/definitions/Text",
+          },
+          "type": "array",
+        },
+        "data": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "target": Object {
+              "$ref": "#/definitions/ResourceLink",
+            },
+          },
+          "required": Array [
+            "target",
+          ],
+          "type": "object",
+        },
+        "nodeType": Object {
+          "enum": Array [
+            "resource-hyperlink",
+          ],
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ResourceLink": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "sys": Object {
+          "additionalProperties": false,
+          "properties": Object {
+            "linkType": Object {
+              "enum": Array [
+                "Contentful:Entry",
+              ],
+              "type": "string",
+            },
+            "type": Object {
+              "enum": Array [
+                "ResourceLink",
+              ],
+              "type": "string",
+            },
+            "urn": Object {
+              "type": "string",
+            },
+          },
+          "required": Array [
+            "linkType",
+            "type",
+            "urn",
+          ],
+          "type": "object",
+        },
+      },
+      "required": Array [
+        "sys",
+      ],
+      "type": "object",
+    },
+    "Text": Object {
+      "additionalProperties": false,
+      "properties": Object {
+        "data": Object {
+          "$ref": "#/definitions/NodeData",
+        },
+        "marks": Object {
+          "items": Object {
+            "$ref": "#/definitions/Mark",
+          },
+          "type": "array",
+        },
+        "nodeType": Object {
+          "enum": Array [
+            "text",
+          ],
+          "type": "string",
+        },
+        "value": Object {
+          "type": "string",
+        },
+      },
+      "required": Array [
+        "data",
+        "marks",
+        "nodeType",
+        "value",
+      ],
+      "type": "object",
+    },
+  },
+}
+`;
+
 exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] = `
 Object {
   "$ref": "#/definitions/Table",
@@ -2910,8 +3191,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -3132,8 +3415,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -3298,8 +3583,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -3463,8 +3750,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },
@@ -3771,8 +4060,10 @@ Object {
       "enum": Array [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
         "hyperlink",
+        "resource-hyperlink",
       ],
       "type": "string",
     },

--- a/packages/rich-text-types/src/schemas/generated/blockquote.json
+++ b/packages/rich-text-types/src/schemas/generated/blockquote.json
@@ -97,8 +97,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/document.json
+++ b/packages/rich-text-types/src/schemas/generated/document.json
@@ -174,8 +174,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/embedded-asset-block.json
+++ b/packages/rich-text-types/src/schemas/generated/embedded-asset-block.json
@@ -114,8 +114,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/embedded-entry-block.json
+++ b/packages/rich-text-types/src/schemas/generated/embedded-entry-block.json
@@ -114,8 +114,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/embedded-resource-block.json
+++ b/packages/rich-text-types/src/schemas/generated/embedded-resource-block.json
@@ -114,8 +114,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/embedded-resource-inline.json
+++ b/packages/rich-text-types/src/schemas/generated/embedded-resource-inline.json
@@ -1,30 +1,32 @@
 {
-  "$ref": "#/definitions/Heading3",
+  "$ref": "#/definitions/ResourceLinkInline",
   "definitions": {
-    "Heading3": {
+    "ResourceLinkInline": {
       "type": "object",
       "properties": {
         "nodeType": {
           "type": "string",
           "enum": [
-            "heading-3"
+            "embedded-resource-inline"
           ]
         },
         "data": {
           "type": "object",
-          "properties": {}
+          "properties": {
+            "target": {
+              "$ref": "#/definitions/Link<\"Entry\">"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "target"
+          ]
         },
         "content": {
+          "maxItems": 0,
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Inline"
-              },
-              {
-                "$ref": "#/definitions/Text"
-              }
-            ]
+            "$ref": "#/definitions/Text"
           }
         }
       },
@@ -35,47 +37,40 @@
         "nodeType"
       ]
     },
-    "Inline": {
+    "Link<\"Entry\">": {
       "type": "object",
       "properties": {
-        "nodeType": {
-          "$ref": "#/definitions/INLINES"
-        },
-        "content": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Inline"
-              },
-              {
-                "$ref": "#/definitions/Text"
-              }
-            ]
-          }
-        },
-        "data": {
-          "$ref": "#/definitions/NodeData"
+        "sys": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "Link"
+              ]
+            },
+            "linkType": {
+              "type": "string",
+              "enum": [
+                "Entry"
+              ]
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "linkType",
+            "type"
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "content",
-        "data",
-        "nodeType"
+        "sys"
       ]
-    },
-    "INLINES": {
-      "description": "Map of all Contentful inline types. Inline contain inline or text nodes.",
-      "enum": [
-        "asset-hyperlink",
-        "embedded-entry-inline",
-        "embedded-resource-inline",
-        "entry-hyperlink",
-        "hyperlink",
-        "resource-hyperlink"
-      ],
-      "type": "string"
     },
     "Text": {
       "type": "object",

--- a/packages/rich-text-types/src/schemas/generated/embedded-resource-inline.json
+++ b/packages/rich-text-types/src/schemas/generated/embedded-resource-inline.json
@@ -14,7 +14,7 @@
           "type": "object",
           "properties": {
             "target": {
-              "$ref": "#/definitions/Link<\"Entry\">"
+              "$ref": "#/definitions/ResourceLink"
             }
           },
           "additionalProperties": false,
@@ -37,7 +37,7 @@
         "nodeType"
       ]
     },
-    "Link<\"Entry\">": {
+    "ResourceLink": {
       "type": "object",
       "properties": {
         "sys": {
@@ -46,24 +46,24 @@
             "type": {
               "type": "string",
               "enum": [
-                "Link"
+                "ResourceLink"
               ]
             },
             "linkType": {
               "type": "string",
               "enum": [
-                "Entry"
+                "Contentful:Entry"
               ]
             },
-            "id": {
+            "urn": {
               "type": "string"
             }
           },
           "additionalProperties": false,
           "required": [
-            "id",
             "linkType",
-            "type"
+            "type",
+            "urn"
           ]
         }
       },

--- a/packages/rich-text-types/src/schemas/generated/heading-1.json
+++ b/packages/rich-text-types/src/schemas/generated/heading-1.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/heading-2.json
+++ b/packages/rich-text-types/src/schemas/generated/heading-2.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/heading-4.json
+++ b/packages/rich-text-types/src/schemas/generated/heading-4.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/heading-5.json
+++ b/packages/rich-text-types/src/schemas/generated/heading-5.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/heading-6.json
+++ b/packages/rich-text-types/src/schemas/generated/heading-6.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/hr.json
+++ b/packages/rich-text-types/src/schemas/generated/hr.json
@@ -71,8 +71,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/list-item.json
+++ b/packages/rich-text-types/src/schemas/generated/list-item.json
@@ -174,8 +174,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/ordered-list.json
+++ b/packages/rich-text-types/src/schemas/generated/ordered-list.json
@@ -201,8 +201,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/paragraph.json
+++ b/packages/rich-text-types/src/schemas/generated/paragraph.json
@@ -70,8 +70,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/resource-hyperlink.json
+++ b/packages/rich-text-types/src/schemas/generated/resource-hyperlink.json
@@ -1,30 +1,31 @@
 {
-  "$ref": "#/definitions/Heading3",
+  "$ref": "#/definitions/ResourceHyperlink",
   "definitions": {
-    "Heading3": {
+    "ResourceHyperlink": {
       "type": "object",
       "properties": {
         "nodeType": {
           "type": "string",
           "enum": [
-            "heading-3"
+            "resource-hyperlink"
           ]
         },
         "data": {
           "type": "object",
-          "properties": {}
+          "properties": {
+            "target": {
+              "$ref": "#/definitions/ResourceLink"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "target"
+          ]
         },
         "content": {
           "type": "array",
           "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Inline"
-              },
-              {
-                "$ref": "#/definitions/Text"
-              }
-            ]
+            "$ref": "#/definitions/Text"
           }
         }
       },
@@ -35,47 +36,40 @@
         "nodeType"
       ]
     },
-    "Inline": {
+    "ResourceLink": {
       "type": "object",
       "properties": {
-        "nodeType": {
-          "$ref": "#/definitions/INLINES"
-        },
-        "content": {
-          "type": "array",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/Inline"
-              },
-              {
-                "$ref": "#/definitions/Text"
-              }
-            ]
-          }
-        },
-        "data": {
-          "$ref": "#/definitions/NodeData"
+        "sys": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ResourceLink"
+              ]
+            },
+            "linkType": {
+              "type": "string",
+              "enum": [
+                "Contentful:Entry"
+              ]
+            },
+            "urn": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "linkType",
+            "type",
+            "urn"
+          ]
         }
       },
       "additionalProperties": false,
       "required": [
-        "content",
-        "data",
-        "nodeType"
+        "sys"
       ]
-    },
-    "INLINES": {
-      "description": "Map of all Contentful inline types. Inline contain inline or text nodes.",
-      "enum": [
-        "asset-hyperlink",
-        "embedded-entry-inline",
-        "embedded-resource-inline",
-        "entry-hyperlink",
-        "hyperlink",
-        "resource-hyperlink"
-      ],
-      "type": "string"
     },
     "Text": {
       "type": "object",

--- a/packages/rich-text-types/src/schemas/generated/table-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-cell.json
@@ -107,8 +107,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/table-header-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-header-cell.json
@@ -106,8 +106,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/table-row.json
+++ b/packages/rich-text-types/src/schemas/generated/table-row.json
@@ -135,8 +135,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/table.json
+++ b/packages/rich-text-types/src/schemas/generated/table.json
@@ -163,8 +163,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/src/schemas/generated/unordered-list.json
+++ b/packages/rich-text-types/src/schemas/generated/unordered-list.json
@@ -201,8 +201,10 @@
       "enum": [
         "asset-hyperlink",
         "embedded-entry-inline",
+        "embedded-resource-inline",
         "entry-hyperlink",
-        "hyperlink"
+        "hyperlink",
+        "resource-hyperlink"
       ],
       "type": "string"
     },

--- a/packages/rich-text-types/tools/jsonSchemaGen.ts
+++ b/packages/rich-text-types/tools/jsonSchemaGen.ts
@@ -64,7 +64,9 @@ const inlineSymbolsMap = new Map([
   [INLINES.HYPERLINK, 'Hyperlink'],
   [INLINES.ENTRY_HYPERLINK, 'EntryHyperlink'],
   [INLINES.ASSET_HYPERLINK, 'AssetHyperlink'],
+  [INLINES.RESOURCE_HYPERLINK, 'ResourceHyperlink'],
   [INLINES.EMBEDDED_ENTRY, 'EntryLinkInline'],
+  [INLINES.EMBEDDED_RESOURCE, 'ResourceLinkInline'],
 ]);
 
 Object.values(BLOCKS).forEach((nodeType) => {


### PR DESCRIPTION
- Add `embedded-resource-inline` and `resource-hyperlink` nodes
- `getAllRichTextResourceLinks` to find all resource links regardless of node type

[DANTE-1157](https://contentful.atlassian.net/browse/DANTE-1157)

[DANTE-1157]: https://contentful.atlassian.net/browse/DANTE-1157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ