### PR TITLE
feat: preserve whitespace (linebreak and multiple spaces)  [TOL-1056]

### DIFF
--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -332,4 +332,85 @@ describe('documentToHtmlString', () => {
   it('does not crash with undefined documents', () => {
     expect(documentToHtmlString(undefined as Document)).toEqual('');
   });
+
+  it('preserves whitespace with preserveWhitespace option', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'hello    world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    const options: Options = {
+      preserveWhitespace: true,
+    };
+    const expected = '<p>hello&nbsp;&nbsp;&nbsp;&nbsp;world</p>';
+
+    expect(documentToHtmlString(document, options)).toEqual(expected);
+  });
+
+  it('preserves line breaks with preserveWhitespace option', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'hello\nworld',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    const options: Options = {
+      preserveWhitespace: true,
+    };
+    const expected = '<p>hello<br/>world</p>';
+
+    expect(documentToHtmlString(document, options)).toEqual(expected);
+  });
+
+  it('preserves both spaces and line breaks with preserveWhitespace option', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'hello   \n  world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    const options: Options = {
+      preserveWhitespace: true,
+    };
+    const expected = '<p>hello&nbsp;&nbsp;&nbsp;<br/>&nbsp;&nbsp;world</p>';
+
+    expect(documentToHtmlString(document, options)).toEqual(expected);
+  });
 });

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -11,14 +11,14 @@ Array [
 exports[`documentToReactComponents renders asset hyperlink 1`] = `
 Array [
   <p>
-    
+
     <span>
-      type: 
+      type:
       asset-hyperlink
-       id: 
+       id:
       9mpxT4zsRi6Iwukey8KeM
     </span>
-    
+
   </p>,
 ]
 `;
@@ -49,14 +49,14 @@ Array [
 exports[`documentToReactComponents renders embedded entry 1`] = `
 Array [
   <p>
-    
+
     <span>
-      type: 
+      type:
       embedded-entry-inline
-       id: 
+       id:
       9mpxT4zsRi6Iwukey8KeM
     </span>
-    
+
   </p>,
 ]
 `;
@@ -72,14 +72,14 @@ Array [
 exports[`documentToReactComponents renders entry hyperlink 1`] = `
 Array [
   <p>
-    
+
     <span>
-      type: 
+      type:
       entry-hyperlink
-       id: 
+       id:
       9mpxT4zsRi6Iwukey8KeM
     </span>
-    
+
   </p>,
 ]
 `;
@@ -91,7 +91,7 @@ Array [
   </p>,
   <hr />,
   <p>
-    
+
   </p>,
 ]
 `;
@@ -99,7 +99,7 @@ Array [
 exports[`documentToReactComponents renders hyperlink 1`] = `
 Array [
   <p>
-    Some text 
+    Some text
     <a
       href="https://url.org"
     >
@@ -244,7 +244,7 @@ Array [
     </li>
   </ol>,
   <p>
-    
+
   </p>,
 ]
 `;
@@ -346,7 +346,7 @@ Array [
     </li>
   </ul>,
   <p>
-    
+
   </p>,
 ]
 `;
@@ -358,7 +358,7 @@ Array [
   </p>,
   <hr />,
   <p>
-    
+
   </p>,
 ]
 `;
@@ -420,4 +420,22 @@ exports[`nodeToReactComponent renders valid nodes 1`] = `
 <p>
   hello world
 </p>
+`;
+
+exports[`preserveWhitespace preserves new lines 1`] = `
+Array [
+  <p>
+    hello
+    <br />
+    world
+  </p>,
+]
+`;
+
+exports[`preserveWhitespace preserves spaces between words 1`] = `
+Array [
+  <p>
+    hello&nbsp;&nbsp;&nbsp;&nbsp;world
+  </p>,
+]
 `;

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -404,3 +404,55 @@ describe('nodeListToReactComponents', () => {
     expect(renderedNodes).toMatchSnapshot();
   });
 });
+
+describe.only('preserveWhitespace', () => {
+  it('preserves spaces between words', () => {
+    const options: Options = {
+      preserveWhitespace: true,
+    };
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'hello    world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    expect(documentToReactComponents(document, options)).toMatchSnapshot();
+  });
+
+  it('preserves new lines', () => {
+    const options: Options = {
+      preserveWhitespace: true,
+    };
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'hello\nworld',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+    expect(documentToReactComponents(document, options)).toMatchSnapshot();
+  });
+});

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -80,6 +80,10 @@ export interface Options {
    * Text renderer
    */
   renderText?: RenderText;
+  /**
+   * Keep line breaks and multiple spaces
+   */
+  preserveWhitespace?: boolean;
 }
 
 /**
@@ -103,5 +107,6 @@ export function documentToReactComponents(
       ...options.renderMark,
     },
     renderText: options.renderText,
+    preserveWhitespace: options.preserveWhitespace,
   });
 }


### PR DESCRIPTION
### Description

Fixes [#96](https://github.com/contentful/rich-text/issues/96)
Ticket: https://contentful.atlassian.net/browse/TOL-1056

The current behavior of the rich-text-html-renderer ignores line breaks, similar to standard browser behavior. This has caused discrepancies between content editor expectations and actual output. Furthermore, extra spaces between words are also not rendered.

To address this without introducing breaking changes, this PR introduces an optional configuration that instructs the renderer to generate HTML that aligns closer to what content editors would expect.

### Changes:

- Implemented the ability to pass an optional configuration to the render function.
- When the configuration is passed, the renderer automatically adds an extra `<br/>` tag for each new line in the Rich Text Editor.
- Extra spaces are handled by outputting `&nbsp;` in the generated HTML.
- This update has been applied to both HTML and React renderers.