### PR TITLE
docs: describe preserve whitespace [TOL-1056]

### DIFF
--- a/packages/rich-text-html-renderer/README.md
+++ b/packages/rich-text-html-renderer/README.md
@@ -175,3 +175,36 @@ The `renderMark` keys should be one of the following `MARKS` properties as defin
 - `CODE`
 - `SUPERSCRIPT`
 - `SUBSCRIPT`
+
+#### Preserving Whitespace
+
+In your HTML rendering options, you can utilize the `preserveWhitespace` boolean flag. When set to `true`, this flag ensures that spaces and line breaks in the Contentful rich text content are preserved in the rendered HTML. Specifically, it replaces consecutive spaces with `&nbsp;` entities and retains line breaks using `<br />` tags. This capability is particularly beneficial for content that has specific formatting requirements involving spaces and line breaks.
+
+```javascript
+import { documentToHtmlString } from '@contentful/rich-text-html-renderer';
+
+const document = {
+  nodeType: 'document',
+  content: [
+    {
+      nodeType: 'paragraph',
+      content: [
+        {
+          nodeType: 'text',
+          value: 'Hello     world!',
+          marks: [],
+        },
+      ],
+    },
+  ],
+};
+
+const options = {
+  preserveWhitespace: true,
+};
+
+documentToHtmlString(document, options);
+// -> <p>Hello&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;world!</p>
+```
+
+With this configuration, the HTML output retains the spaces found between "Hello" and "world!".

--- a/packages/rich-text-react-renderer/README.md
+++ b/packages/rich-text-react-renderer/README.md
@@ -215,3 +215,36 @@ const options = {
   },
 };
 ```
+
+#### Preserving Whitespace
+
+The `options` object can include a `preserveWhitespace` boolean flag. When set to `true`, this flag ensures that multiple spaces in the rich text content are preserved by replacing them with `&nbsp;`, and line breaks are maintained with `<br />` tags. This is useful for content that relies on specific formatting using spaces and line breaks.
+
+```javascript
+import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
+
+const document = {
+  nodeType: 'document',
+  content: [
+    {
+      nodeType: 'paragraph',
+      content: [
+        {
+          nodeType: 'text',
+          value: 'Hello     world!',
+          marks: [],
+        },
+      ],
+    },
+  ],
+};
+
+const options = {
+  preserveWhitespace: true,
+};
+
+documentToReactComponents(document, options);
+// -> <p>Hello&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;world!</p>
+```
+
+In this example, the multiple spaces between "Hello" and "world!" are preserved in the rendered output.

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -11,14 +11,14 @@ Array [
 exports[`documentToReactComponents renders asset hyperlink 1`] = `
 Array [
   <p>
-
+    
     <span>
-      type:
+      type: 
       asset-hyperlink
-       id:
+       id: 
       9mpxT4zsRi6Iwukey8KeM
     </span>
-
+    
   </p>,
 ]
 `;
@@ -49,14 +49,14 @@ Array [
 exports[`documentToReactComponents renders embedded entry 1`] = `
 Array [
   <p>
-
+    
     <span>
-      type:
+      type: 
       embedded-entry-inline
-       id:
+       id: 
       9mpxT4zsRi6Iwukey8KeM
     </span>
-
+    
   </p>,
 ]
 `;
@@ -72,14 +72,14 @@ Array [
 exports[`documentToReactComponents renders entry hyperlink 1`] = `
 Array [
   <p>
-
+    
     <span>
-      type:
+      type: 
       entry-hyperlink
-       id:
+       id: 
       9mpxT4zsRi6Iwukey8KeM
     </span>
-
+    
   </p>,
 ]
 `;
@@ -91,7 +91,7 @@ Array [
   </p>,
   <hr />,
   <p>
-
+    
   </p>,
 ]
 `;
@@ -99,7 +99,7 @@ Array [
 exports[`documentToReactComponents renders hyperlink 1`] = `
 Array [
   <p>
-    Some text
+    Some text 
     <a
       href="https://url.org"
     >
@@ -244,7 +244,7 @@ Array [
     </li>
   </ol>,
   <p>
-
+    
   </p>,
 ]
 `;
@@ -346,7 +346,7 @@ Array [
     </li>
   </ul>,
   <p>
-
+    
   </p>,
 ]
 `;
@@ -358,7 +358,7 @@ Array [
   </p>,
   <hr />,
   <p>
-
+    
   </p>,
 ]
 `;

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -405,7 +405,7 @@ describe('nodeListToReactComponents', () => {
   });
 });
 
-describe.only('preserveWhitespace', () => {
+describe('preserveWhitespace', () => {
   it('preserves spaces between words', () => {
     const options: Options = {
       preserveWhitespace: true,


### PR DESCRIPTION
- remove `.only` in test case
- unrelated snapshots were updated (after auto formatting) in the last PR, which made the tests fail. I reversed those changes.
- add documentation around newly added preserve whitespace option