### PR TITLE
feat: add default renderers for new resource nodes

### DIFF
--- a/packages/rich-text-html-renderer/README.md
+++ b/packages/rich-text-html-renderer/README.md
@@ -163,9 +163,11 @@ The `renderNode` keys should be one of the following `BLOCKS` and `INLINES` prop
 
 - `INLINES`
   - `EMBEDDED_ENTRY` (this is different from the `BLOCKS.EMBEDDED_ENTRY`)
+  - `EMBEDDED_RESOURCE`
   - `HYPERLINK`
   - `ENTRY_HYPERLINK`
   - `ASSET_HYPERLINK`
+  - `RESOURCE_HYPERLINK`
 
 The `renderMark` keys should be one of the following `MARKS` properties as defined in [`@contentful/rich-text-types`](https://www.npmjs.com/package/@contentful/rich-text-types):
 

--- a/packages/rich-text-html-renderer/src/__test__/documents/index.ts
+++ b/packages/rich-text-html-renderer/src/__test__/documents/index.ts
@@ -6,7 +6,7 @@ export { default as paragraphDoc } from './paragraph';
 export { default as headingDoc } from './heading';
 export { default as marksDoc } from './mark';
 export { default as embeddedEntryDoc } from './embedded-entry';
-export { default as embeddedResourceDoc } from './embedded-entry';
+export { default as embeddedResourceDoc } from './embedded-resource';
 export { default as olDoc } from './ol';
 export { default as ulDoc } from './ul';
 export { default as quoteDoc } from './quote';

--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -44,6 +44,22 @@ describe('documentToHtmlString', () => {
         doc: headingDoc(BLOCKS.HEADING_2),
         expected: '<h2>hello world</h2>',
       },
+      {
+        doc: headingDoc(BLOCKS.HEADING_3),
+        expected: '<h3>hello world</h3>',
+      },
+      {
+        doc: headingDoc(BLOCKS.HEADING_4),
+        expected: '<h4>hello world</h4>',
+      },
+      {
+        doc: headingDoc(BLOCKS.HEADING_5),
+        expected: '<h5>hello world</h5>',
+      },
+      {
+        doc: headingDoc(BLOCKS.HEADING_6),
+        expected: '<h6>hello world</h6>',
+      },
     ];
 
     docs.forEach(({ doc, expected }) => {

--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -203,7 +203,7 @@ describe('documentToHtmlString', () => {
   it('renders default resource link block', () => {
     const resourceLink: ResourceLink = {
       sys: {
-        urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/entries/9mpxT4zsRi6Iwukey8KeM',
+        urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
         type: 'ResourceLink',
         linkType: 'Contentful:Entry',
       },
@@ -298,8 +298,8 @@ describe('documentToHtmlString', () => {
       target: {
         sys: {
           id: '9mpxT4zsRi6Iwukey8KeM',
-          link: 'Link',
-          type: 'Asset',
+          type: 'Link',
+          linkType: 'Asset',
         },
       },
     };
@@ -314,8 +314,8 @@ describe('documentToHtmlString', () => {
       target: {
         sys: {
           id: '9mpxT4zsRi6Iwukey8KeM',
-          link: 'Link',
-          type: 'Entry',
+          type: 'Link',
+          linkType: 'Entry',
         },
       },
     };
@@ -325,18 +325,50 @@ describe('documentToHtmlString', () => {
     expect(documentToHtmlString(document)).toEqual(expected);
   });
 
+  it('renders resource hyperlink', () => {
+    const entry = {
+      target: {
+        sys: {
+          urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+        },
+      },
+    };
+    const document: Document = inlineEntity(entry, INLINES.RESOURCE_HYPERLINK);
+    const expected = `<p><span>type: ${INLINES.RESOURCE_HYPERLINK} urn: ${entry.target.sys.urn}</span></p>`;
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
   it('renders embedded entry', () => {
     const entry = {
       target: {
         sys: {
           id: '9mpxT4zsRi6Iwukey8KeM',
-          link: 'Link',
-          type: 'Entry',
+          type: 'Link',
+          linkType: 'Entry',
         },
       },
     };
     const document: Document = inlineEntity(entry, INLINES.EMBEDDED_ENTRY);
     const expected = `<p><span>type: ${INLINES.EMBEDDED_ENTRY} id: ${entry.target.sys.id}</span></p>`;
+
+    expect(documentToHtmlString(document)).toEqual(expected);
+  });
+
+  it('renders embedded resource', () => {
+    const entry = {
+      target: {
+        sys: {
+          urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
+          type: 'Link',
+          linkType: 'Contentful:Entry',
+        },
+      },
+    };
+    const document: Document = inlineEntity(entry, INLINES.EMBEDDED_RESOURCE);
+    const expected = `<p><span>type: ${INLINES.EMBEDDED_RESOURCE} urn: ${entry.target.sys.urn}</span></p>`;
 
     expect(documentToHtmlString(document)).toEqual(expected);
   });

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -34,7 +34,11 @@ const defaultNodeRenderers: RenderNode = {
   [BLOCKS.TABLE_CELL]: (node, next) => `<td>${next(node.content)}</td>`,
   [INLINES.ASSET_HYPERLINK]: (node) => defaultInline(INLINES.ASSET_HYPERLINK, node as Inline),
   [INLINES.ENTRY_HYPERLINK]: (node) => defaultInline(INLINES.ENTRY_HYPERLINK, node as Inline),
+  [INLINES.RESOURCE_HYPERLINK]: (node) =>
+    defaultInlineResource(INLINES.RESOURCE_HYPERLINK, node as Inline),
   [INLINES.EMBEDDED_ENTRY]: (node) => defaultInline(INLINES.EMBEDDED_ENTRY, node as Inline),
+  [INLINES.EMBEDDED_RESOURCE]: (node) =>
+    defaultInlineResource(INLINES.EMBEDDED_RESOURCE, node as Inline),
   [INLINES.HYPERLINK]: (node, next) => {
     const href = typeof node.data.uri === 'string' ? node.data.uri : '';
     return `<a href=${attributeValue(href)}>${next(node.content)}</a>`;
@@ -52,6 +56,9 @@ const defaultMarkRenderers: RenderMark = {
 
 const defaultInline = (type: string, node: Inline) =>
   `<span>type: ${escape(type)} id: ${escape(node.data.target.sys.id)}</span>`;
+
+const defaultInlineResource = (type: string, node: Inline) =>
+  `<span>type: ${escape(type)} urn: ${escape(node.data.target.sys.urn)}</span>`;
 
 export type CommonNode = Text | Block | Inline;
 

--- a/packages/rich-text-react-renderer/README.md
+++ b/packages/rich-text-react-renderer/README.md
@@ -177,9 +177,11 @@ The `renderNode` keys should be one of the following `BLOCKS` and `INLINES` prop
 
 - `INLINES`
   - `EMBEDDED_ENTRY` (this is different from the `BLOCKS.EMBEDDED_ENTRY`)
+  - `EMBEDDED_RESOURCE`
   - `HYPERLINK`
   - `ENTRY_HYPERLINK`
   - `ASSET_HYPERLINK`
+  - `RESOURCE_HYPERLINK`
 
 The `renderMark` keys should be one of the following `MARKS` properties as defined in [`@contentful/rich-text-types`](https://www.npmjs.com/package/@contentful/rich-text-types):
 

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -61,6 +61,21 @@ Array [
 ]
 `;
 
+exports[`documentToReactComponents renders embedded resource 1`] = `
+Array [
+  <p>
+    
+    <span>
+      type: 
+      embedded-resource-inline
+       urn: 
+      crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM
+    </span>
+    
+  </p>,
+]
+`;
+
 exports[`documentToReactComponents renders empty node if type is not recognized 1`] = `
 Array [
   <React.Fragment>
@@ -218,6 +233,38 @@ Array [
 ]
 `;
 
+exports[`documentToReactComponents renders nodes with default node renderer 4`] = `
+Array [
+  <h3>
+    hello world
+  </h3>,
+]
+`;
+
+exports[`documentToReactComponents renders nodes with default node renderer 5`] = `
+Array [
+  <h4>
+    hello world
+  </h4>,
+]
+`;
+
+exports[`documentToReactComponents renders nodes with default node renderer 6`] = `
+Array [
+  <h5>
+    hello world
+  </h5>,
+]
+`;
+
+exports[`documentToReactComponents renders nodes with default node renderer 7`] = `
+Array [
+  <h6>
+    hello world
+  </h6>,
+]
+`;
+
 exports[`documentToReactComponents renders nodes with passed custom node renderer 1`] = `
 <Document>
   <Paragraph>
@@ -244,6 +291,21 @@ Array [
     </li>
   </ol>,
   <p>
+    
+  </p>,
+]
+`;
+
+exports[`documentToReactComponents renders resource hyperlink 1`] = `
+Array [
+  <p>
+    
+    <span>
+      type: 
+      resource-hyperlink
+       urn: 
+      crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM
+    </span>
     
   </p>,
 ]

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -50,6 +50,10 @@ describe('documentToReactComponents', () => {
       paragraphDoc,
       headingDoc(BLOCKS.HEADING_1),
       headingDoc(BLOCKS.HEADING_2),
+      headingDoc(BLOCKS.HEADING_3),
+      headingDoc(BLOCKS.HEADING_4),
+      headingDoc(BLOCKS.HEADING_5),
+      headingDoc(BLOCKS.HEADING_6),
     ];
 
     docs.forEach((doc) => {
@@ -142,7 +146,7 @@ describe('documentToReactComponents', () => {
   it('renders default resource block', () => {
     const resourceSys: ResourceLink = {
       sys: {
-        urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/entries/9mpxT4zsRi6Iwukey8KeM',
+        urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
         type: 'ResourceLink',
         linkType: 'Contentful:Entry',
       },
@@ -217,12 +221,26 @@ describe('documentToReactComponents', () => {
       target: {
         sys: {
           id: '9mpxT4zsRi6Iwukey8KeM',
-          link: 'Link',
-          type: 'Entry',
+          type: 'Link',
+          linkType: 'Entry',
         },
       },
     };
     const document: Document = inlineEntityDoc(entry, INLINES.ENTRY_HYPERLINK);
+
+    expect(documentToReactComponents(document)).toMatchSnapshot();
+  });
+  it('renders resource hyperlink', () => {
+    const entry = {
+      target: {
+        sys: {
+          urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
+          type: 'Link',
+          linkType: 'Entry',
+        },
+      },
+    };
+    const document: Document = inlineEntityDoc(entry, INLINES.RESOURCE_HYPERLINK);
 
     expect(documentToReactComponents(document)).toMatchSnapshot();
   });
@@ -231,12 +249,26 @@ describe('documentToReactComponents', () => {
       target: {
         sys: {
           id: '9mpxT4zsRi6Iwukey8KeM',
-          link: 'Link',
-          type: 'Entry',
+          type: 'Link',
+          linkType: 'Entry',
         },
       },
     };
     const document: Document = inlineEntityDoc(entry, INLINES.EMBEDDED_ENTRY);
+
+    expect(documentToReactComponents(document)).toMatchSnapshot();
+  });
+  it('renders embedded resource', () => {
+    const entry = {
+      target: {
+        sys: {
+          urn: 'crn:contentful:::content:spaces/6fqi4ljzyr0e/environments/master/entries/9mpxT4zsRi6Iwukey8KeM',
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+        },
+      },
+    };
+    const document: Document = inlineEntityDoc(entry, INLINES.EMBEDDED_RESOURCE);
 
     expect(documentToReactComponents(document)).toMatchSnapshot();
   });

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -28,7 +28,11 @@ const defaultNodeRenderers: RenderNode = {
   [BLOCKS.TABLE_CELL]: (node, children) => <td>{children}</td>,
   [INLINES.ASSET_HYPERLINK]: (node) => defaultInline(INLINES.ASSET_HYPERLINK, node as Inline),
   [INLINES.ENTRY_HYPERLINK]: (node) => defaultInline(INLINES.ENTRY_HYPERLINK, node as Inline),
+  [INLINES.RESOURCE_HYPERLINK]: (node) =>
+    defaultInlineResource(INLINES.RESOURCE_HYPERLINK, node as Inline),
   [INLINES.EMBEDDED_ENTRY]: (node) => defaultInline(INLINES.EMBEDDED_ENTRY, node as Inline),
+  [INLINES.EMBEDDED_RESOURCE]: (node, children) =>
+    defaultInlineResource(INLINES.EMBEDDED_RESOURCE, node as Inline),
   [INLINES.HYPERLINK]: (node, children) => <a href={node.data.uri}>{children}</a>,
 };
 
@@ -45,6 +49,14 @@ function defaultInline(type: string, node: Inline): ReactNode {
   return (
     <span key={node.data.target.sys.id}>
       type: {node.nodeType} id: {node.data.target.sys.id}
+    </span>
+  );
+}
+
+function defaultInlineResource(type: string, node: Inline) {
+  return (
+    <span key={node.data.target.sys.urn}>
+      type: {node.nodeType} urn: {node.data.target.sys.urn}
     </span>
   );
 }


### PR DESCRIPTION
Add HTML and React default renderers for new node types `embedded-resource-block` and `resource-hyperlink`.

I also made some small changes to improve coverage (making it a little easier to see if something is missing).