### PR TITLE
feat: update schema for rich text types [TOL-2249]

### DIFF
--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -198,7 +198,7 @@ export interface ResourceHyperlink extends Inline {
 }
 
 export interface TableCell extends Block {
-  nodeType: BLOCKS.TABLE_HEADER_CELL;
+  nodeType: BLOCKS.TABLE_CELL;
   data: {
     colspan?: number;
     rowspan?: number;
@@ -210,8 +210,12 @@ export interface TableCell extends Block {
   content: Paragraph[] | OrderedList[] | UnorderedList[];
 }
 
-export interface TableHeaderCell extends TableCell {
+export interface TableHeaderCell extends Block {
   nodeType: BLOCKS.TABLE_HEADER_CELL;
+  data: {
+    colspan?: number;
+    rowspan?: number;
+  };
 
   /**
    * @minItems 1

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -198,7 +198,7 @@ export interface ResourceHyperlink extends Inline {
 }
 
 export interface TableCell extends Block {
-  nodeType: BLOCKS.TABLE_HEADER_CELL | BLOCKS.TABLE_CELL;
+  nodeType: BLOCKS.TABLE_HEADER_CELL | BLOCKS.TABLE_CELL | BLOCKS.OL_LIST | BLOCKS.UL_LIST;
   data: {
     colspan?: number;
     rowspan?: number;

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -207,7 +207,7 @@ export interface TableCell extends Block {
   /**
    * @minItems 1
    */
-  content: Paragraph[] | OrderedList[] | UnorderedList[];
+  content: (Paragraph | OrderedList | UnorderedList)[];
 }
 
 export interface TableHeaderCell extends Block {
@@ -232,7 +232,7 @@ export interface TableRow extends Block {
   /**
    * @minItems 1
    */
-  content: TableCell[];
+  content: (TableCell | TableHeaderCell)[];
 }
 
 export interface Table extends Block {

--- a/packages/rich-text-types/src/nodeTypes.ts
+++ b/packages/rich-text-types/src/nodeTypes.ts
@@ -198,7 +198,7 @@ export interface ResourceHyperlink extends Inline {
 }
 
 export interface TableCell extends Block {
-  nodeType: BLOCKS.TABLE_HEADER_CELL | BLOCKS.TABLE_CELL | BLOCKS.OL_LIST | BLOCKS.UL_LIST;
+  nodeType: BLOCKS.TABLE_HEADER_CELL;
   data: {
     colspan?: number;
     rowspan?: number;
@@ -207,11 +207,16 @@ export interface TableCell extends Block {
   /**
    * @minItems 1
    */
-  content: Paragraph[];
+  content: Paragraph[] | OrderedList[] | UnorderedList[];
 }
 
 export interface TableHeaderCell extends TableCell {
   nodeType: BLOCKS.TABLE_HEADER_CELL;
+
+  /**
+   * @minItems 1
+   */
+  content: Paragraph[];
 }
 
 // An abstract table row can have both table cell types

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -3186,6 +3186,65 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
   "$ref": "#/definitions/Table",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell",
+      ],
+      "type": "string",
+    },
+    "Block": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
     "INLINES": {
       "description": "Map of all Contentful inline types. Inline contain inline or text nodes.",
       "enum": [
@@ -3228,6 +3287,85 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
       ],
       "type": "object",
     },
+    "ListItem": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItemBlock",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "list-item",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list",
+      ],
+      "type": "string",
+    },
     "Mark": {
       "additionalProperties": false,
       "properties": {
@@ -3242,6 +3380,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
     },
     "NodeData": {
       "additionalProperties": true,
+      "type": "object",
+    },
+    "OrderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "ordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
       "type": "object",
     },
     "Paragraph": {
@@ -3310,11 +3475,27 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
       "additionalProperties": false,
       "properties": {
         "content": {
-          "items": {
-            "$ref": "#/definitions/Paragraph",
-          },
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/Paragraph",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderedList",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/UnorderedList",
+              },
+              "type": "array",
+            },
+          ],
           "minItems": 1,
-          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -3330,10 +3511,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
         },
         "nodeType": {
           "enum": [
-            "ordered-list",
-            "table-cell",
             "table-header-cell",
-            "unordered-list",
           ],
           "type": "string",
         },
@@ -3403,6 +3581,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
       ],
       "type": "object",
     },
+    "UnorderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "unordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
   },
 }
 `;
@@ -3412,6 +3617,65 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
   "$ref": "#/definitions/TableCell",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell",
+      ],
+      "type": "string",
+    },
+    "Block": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
     "INLINES": {
       "description": "Map of all Contentful inline types. Inline contain inline or text nodes.",
       "enum": [
@@ -3454,6 +3718,85 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
       ],
       "type": "object",
     },
+    "ListItem": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItemBlock",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "list-item",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list",
+      ],
+      "type": "string",
+    },
     "Mark": {
       "additionalProperties": false,
       "properties": {
@@ -3468,6 +3811,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
     },
     "NodeData": {
       "additionalProperties": true,
+      "type": "object",
+    },
+    "OrderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "ordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
       "type": "object",
     },
     "Paragraph": {
@@ -3508,11 +3878,27 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
       "additionalProperties": false,
       "properties": {
         "content": {
-          "items": {
-            "$ref": "#/definitions/Paragraph",
-          },
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/Paragraph",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderedList",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/UnorderedList",
+              },
+              "type": "array",
+            },
+          ],
           "minItems": 1,
-          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -3528,10 +3914,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
         },
         "nodeType": {
           "enum": [
-            "ordered-list",
-            "table-cell",
             "table-header-cell",
-            "unordered-list",
           ],
           "type": "string",
         },
@@ -3570,6 +3953,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
         "marks",
         "nodeType",
         "value",
+      ],
+      "type": "object",
+    },
+    "UnorderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "unordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
       ],
       "type": "object",
     },
@@ -3749,6 +4159,65 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
   "$ref": "#/definitions/TableRow",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell",
+      ],
+      "type": "string",
+    },
+    "Block": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
     "INLINES": {
       "description": "Map of all Contentful inline types. Inline contain inline or text nodes.",
       "enum": [
@@ -3791,6 +4260,85 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
       ],
       "type": "object",
     },
+    "ListItem": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItemBlock",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "list-item",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block",
+              },
+              {
+                "$ref": "#/definitions/Inline",
+              },
+              {
+                "$ref": "#/definitions/Text",
+              },
+            ],
+          },
+          "type": "array",
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData",
+        },
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list",
+      ],
+      "type": "string",
+    },
     "Mark": {
       "additionalProperties": false,
       "properties": {
@@ -3805,6 +4353,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
     },
     "NodeData": {
       "additionalProperties": true,
+      "type": "object",
+    },
+    "OrderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "ordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
       "type": "object",
     },
     "Paragraph": {
@@ -3845,11 +4420,27 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
       "additionalProperties": false,
       "properties": {
         "content": {
-          "items": {
-            "$ref": "#/definitions/Paragraph",
-          },
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/Paragraph",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderedList",
+              },
+              "type": "array",
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/UnorderedList",
+              },
+              "type": "array",
+            },
+          ],
           "minItems": 1,
-          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -3865,10 +4456,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
         },
         "nodeType": {
           "enum": [
-            "ordered-list",
-            "table-cell",
             "table-header-cell",
-            "unordered-list",
           ],
           "type": "string",
         },
@@ -3935,6 +4523,33 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
         "marks",
         "nodeType",
         "value",
+      ],
+      "type": "object",
+    },
+    "UnorderedList": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/ListItem",
+          },
+          "type": "array",
+        },
+        "data": {
+          "properties": {},
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "unordered-list",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
       ],
       "type": "object",
     },

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -3511,7 +3511,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
         },
         "nodeType": {
           "enum": [
-            "table-header-cell",
+            "table-cell",
           ],
           "type": "string",
         },
@@ -3914,7 +3914,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
         },
         "nodeType": {
           "enum": [
-            "table-header-cell",
+            "table-cell",
           ],
           "type": "string",
         },
@@ -4456,7 +4456,7 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
         },
         "nodeType": {
           "enum": [
-            "table-header-cell",
+            "table-cell",
           ],
           "type": "string",
         },

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -3330,8 +3330,10 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
         },
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
             "table-header-cell",
+            "unordered-list",
           ],
           "type": "string",
         },
@@ -3526,8 +3528,10 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
         },
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
             "table-header-cell",
+            "unordered-list",
           ],
           "type": "string",
         },
@@ -3861,8 +3865,10 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
         },
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
             "table-header-cell",
+            "unordered-list",
           ],
           "type": "string",
         },

--- a/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
+++ b/packages/rich-text-types/src/schemas/__test__/__snapshots__/schemas.test.ts.snap
@@ -3475,27 +3475,21 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
       "additionalProperties": false,
       "properties": {
         "content": {
-          "anyOf": [
-            {
-              "items": {
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/OrderedList",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/UnorderedList",
               },
-              "type": "array",
-            },
-          ],
+            ],
+          },
           "minItems": 1,
+          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -3523,12 +3517,55 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table 1`] 
       ],
       "type": "object",
     },
+    "TableHeaderCell": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/Paragraph",
+          },
+          "minItems": 1,
+          "type": "array",
+        },
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "colspan": {
+              "type": "number",
+            },
+            "rowspan": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "table-header-cell",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
     "TableRow": {
       "additionalProperties": false,
       "properties": {
         "content": {
           "items": {
-            "$ref": "#/definitions/TableCell",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TableCell",
+              },
+              {
+                "$ref": "#/definitions/TableHeaderCell",
+              },
+            ],
           },
           "minItems": 1,
           "type": "array",
@@ -3878,27 +3915,21 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-cell
       "additionalProperties": false,
       "properties": {
         "content": {
-          "anyOf": [
-            {
-              "items": {
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/OrderedList",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/UnorderedList",
               },
-              "type": "array",
-            },
-          ],
+            ],
+          },
           "minItems": 1,
+          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -4420,27 +4451,21 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
       "additionalProperties": false,
       "properties": {
         "content": {
-          "anyOf": [
-            {
-              "items": {
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/OrderedList",
               },
-              "type": "array",
-            },
-            {
-              "items": {
+              {
                 "$ref": "#/definitions/UnorderedList",
               },
-              "type": "array",
-            },
-          ],
+            ],
+          },
           "minItems": 1,
+          "type": "array",
         },
         "data": {
           "additionalProperties": false,
@@ -4468,12 +4493,55 @@ exports[`getSchemaWithNodeType returns json schema for each nodeType: table-row 
       ],
       "type": "object",
     },
+    "TableHeaderCell": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "items": {
+            "$ref": "#/definitions/Paragraph",
+          },
+          "minItems": 1,
+          "type": "array",
+        },
+        "data": {
+          "additionalProperties": false,
+          "properties": {
+            "colspan": {
+              "type": "number",
+            },
+            "rowspan": {
+              "type": "number",
+            },
+          },
+          "type": "object",
+        },
+        "nodeType": {
+          "enum": [
+            "table-header-cell",
+          ],
+          "type": "string",
+        },
+      },
+      "required": [
+        "content",
+        "data",
+        "nodeType",
+      ],
+      "type": "object",
+    },
     "TableRow": {
       "additionalProperties": false,
       "properties": {
         "content": {
           "items": {
-            "$ref": "#/definitions/TableCell",
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TableCell",
+              },
+              {
+                "$ref": "#/definitions/TableHeaderCell",
+              },
+            ],
           },
           "minItems": 1,
           "type": "array",

--- a/packages/rich-text-types/src/schemas/generated/table-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-cell.json
@@ -6,8 +6,10 @@
       "properties": {
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
-            "table-header-cell"
+            "table-header-cell",
+            "unordered-list"
           ],
           "type": "string"
         },

--- a/packages/rich-text-types/src/schemas/generated/table-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-cell.json
@@ -24,26 +24,20 @@
         },
         "content": {
           "minItems": 1,
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/OrderedList"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/UnorderedList"
               }
-            }
-          ]
+            ]
+          }
         }
       },
       "additionalProperties": false,

--- a/packages/rich-text-types/src/schemas/generated/table-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-cell.json
@@ -5,13 +5,10 @@
       "type": "object",
       "properties": {
         "nodeType": {
+          "type": "string",
           "enum": [
-            "ordered-list",
-            "table-cell",
-            "table-header-cell",
-            "unordered-list"
-          ],
-          "type": "string"
+            "table-header-cell"
+          ]
         },
         "data": {
           "type": "object",
@@ -27,10 +24,26 @@
         },
         "content": {
           "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Paragraph"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Paragraph"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OrderedList"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnorderedList"
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -161,6 +174,198 @@
     "NodeData": {
       "additionalProperties": true,
       "type": "object"
+    },
+    "OrderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "ordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItem": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "list-item"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItemBlock"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlock": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list"
+      ],
+      "type": "string"
+    },
+    "Block": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "type": "string",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell"
+      ]
+    },
+    "UnorderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "unordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/packages/rich-text-types/src/schemas/generated/table-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-cell.json
@@ -7,7 +7,7 @@
         "nodeType": {
           "type": "string",
           "enum": [
-            "table-header-cell"
+            "table-cell"
           ]
         },
         "data": {

--- a/packages/rich-text-types/src/schemas/generated/table-header-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-header-cell.json
@@ -10,6 +10,13 @@
             "table-header-cell"
           ]
         },
+        "content": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Paragraph"
+          }
+        },
         "data": {
           "type": "object",
           "properties": {
@@ -21,13 +28,6 @@
             }
           },
           "additionalProperties": false
-        },
-        "content": {
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Paragraph"
-          }
         }
       },
       "additionalProperties": false,

--- a/packages/rich-text-types/src/schemas/generated/table-header-cell.json
+++ b/packages/rich-text-types/src/schemas/generated/table-header-cell.json
@@ -10,13 +10,6 @@
             "table-header-cell"
           ]
         },
-        "content": {
-          "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Paragraph"
-          }
-        },
         "data": {
           "type": "object",
           "properties": {
@@ -28,6 +21,13 @@
             }
           },
           "additionalProperties": false
+        },
+        "content": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Paragraph"
+          }
         }
       },
       "additionalProperties": false,

--- a/packages/rich-text-types/src/schemas/generated/table-row.json
+++ b/packages/rich-text-types/src/schemas/generated/table-row.json
@@ -34,8 +34,10 @@
       "properties": {
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
-            "table-header-cell"
+            "table-header-cell",
+            "unordered-list"
           ],
           "type": "string"
         },

--- a/packages/rich-text-types/src/schemas/generated/table-row.json
+++ b/packages/rich-text-types/src/schemas/generated/table-row.json
@@ -33,13 +33,10 @@
       "type": "object",
       "properties": {
         "nodeType": {
+          "type": "string",
           "enum": [
-            "ordered-list",
-            "table-cell",
-            "table-header-cell",
-            "unordered-list"
-          ],
-          "type": "string"
+            "table-header-cell"
+          ]
         },
         "data": {
           "type": "object",
@@ -55,10 +52,26 @@
         },
         "content": {
           "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Paragraph"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Paragraph"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OrderedList"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnorderedList"
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -189,6 +202,198 @@
     "NodeData": {
       "additionalProperties": true,
       "type": "object"
+    },
+    "OrderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "ordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItem": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "list-item"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItemBlock"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlock": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list"
+      ],
+      "type": "string"
+    },
+    "Block": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "type": "string",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell"
+      ]
+    },
+    "UnorderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "unordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"

--- a/packages/rich-text-types/src/schemas/generated/table-row.json
+++ b/packages/rich-text-types/src/schemas/generated/table-row.json
@@ -35,7 +35,7 @@
         "nodeType": {
           "type": "string",
           "enum": [
-            "table-header-cell"
+            "table-cell"
           ]
         },
         "data": {

--- a/packages/rich-text-types/src/schemas/generated/table-row.json
+++ b/packages/rich-text-types/src/schemas/generated/table-row.json
@@ -18,7 +18,14 @@
           "minItems": 1,
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TableCell"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TableCell"
+              },
+              {
+                "$ref": "#/definitions/TableHeaderCell"
+              }
+            ]
           }
         }
       },
@@ -52,26 +59,20 @@
         },
         "content": {
           "minItems": 1,
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/OrderedList"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/UnorderedList"
               }
-            }
-          ]
+            ]
+          }
         }
       },
       "additionalProperties": false,
@@ -385,6 +386,42 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "TableHeaderCell": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "table-header-cell"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "colspan": {
+              "type": "number"
+            },
+            "rowspan": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Paragraph"
           }
         }
       },

--- a/packages/rich-text-types/src/schemas/generated/table.json
+++ b/packages/rich-text-types/src/schemas/generated/table.json
@@ -46,7 +46,14 @@
           "minItems": 1,
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TableCell"
+            "anyOf": [
+              {
+                "$ref": "#/definitions/TableCell"
+              },
+              {
+                "$ref": "#/definitions/TableHeaderCell"
+              }
+            ]
           }
         }
       },
@@ -80,26 +87,20 @@
         },
         "content": {
           "minItems": 1,
-          "anyOf": [
-            {
-              "type": "array",
-              "items": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
                 "$ref": "#/definitions/Paragraph"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/OrderedList"
-              }
-            },
-            {
-              "type": "array",
-              "items": {
+              },
+              {
                 "$ref": "#/definitions/UnorderedList"
               }
-            }
-          ]
+            ]
+          }
         }
       },
       "additionalProperties": false,
@@ -413,6 +414,42 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "TableHeaderCell": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "table-header-cell"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {
+            "colspan": {
+              "type": "number"
+            },
+            "rowspan": {
+              "type": "number"
+            }
+          },
+          "additionalProperties": false
+        },
+        "content": {
+          "minItems": 1,
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Paragraph"
           }
         }
       },

--- a/packages/rich-text-types/src/schemas/generated/table.json
+++ b/packages/rich-text-types/src/schemas/generated/table.json
@@ -63,7 +63,7 @@
         "nodeType": {
           "type": "string",
           "enum": [
-            "table-header-cell"
+            "table-cell"
           ]
         },
         "data": {

--- a/packages/rich-text-types/src/schemas/generated/table.json
+++ b/packages/rich-text-types/src/schemas/generated/table.json
@@ -62,8 +62,10 @@
       "properties": {
         "nodeType": {
           "enum": [
+            "ordered-list",
             "table-cell",
-            "table-header-cell"
+            "table-header-cell",
+            "unordered-list"
           ],
           "type": "string"
         },

--- a/packages/rich-text-types/src/schemas/generated/table.json
+++ b/packages/rich-text-types/src/schemas/generated/table.json
@@ -61,13 +61,10 @@
       "type": "object",
       "properties": {
         "nodeType": {
+          "type": "string",
           "enum": [
-            "ordered-list",
-            "table-cell",
-            "table-header-cell",
-            "unordered-list"
-          ],
-          "type": "string"
+            "table-header-cell"
+          ]
         },
         "data": {
           "type": "object",
@@ -83,10 +80,26 @@
         },
         "content": {
           "minItems": 1,
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/Paragraph"
-          }
+          "anyOf": [
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Paragraph"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/OrderedList"
+              }
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/UnorderedList"
+              }
+            }
+          ]
         }
       },
       "additionalProperties": false,
@@ -217,6 +230,198 @@
     "NodeData": {
       "additionalProperties": true,
       "type": "object"
+    },
+    "OrderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "ordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItem": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "list-item"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItemBlock"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlock": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/ListItemBlockEnum"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "ListItemBlockEnum": {
+      "enum": [
+        "blockquote",
+        "embedded-asset-block",
+        "embedded-entry-block",
+        "embedded-resource-block",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "hr",
+        "ordered-list",
+        "paragraph",
+        "unordered-list"
+      ],
+      "type": "string"
+    },
+    "Block": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "$ref": "#/definitions/BLOCKS"
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Block"
+              },
+              {
+                "$ref": "#/definitions/Inline"
+              },
+              {
+                "$ref": "#/definitions/Text"
+              }
+            ]
+          }
+        },
+        "data": {
+          "$ref": "#/definitions/NodeData"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
+    },
+    "BLOCKS": {
+      "description": "Map of all Contentful block types. Blocks contain inline or block nodes.",
+      "type": "string",
+      "enum": [
+        "document",
+        "paragraph",
+        "heading-1",
+        "heading-2",
+        "heading-3",
+        "heading-4",
+        "heading-5",
+        "heading-6",
+        "ordered-list",
+        "unordered-list",
+        "list-item",
+        "hr",
+        "blockquote",
+        "embedded-entry-block",
+        "embedded-asset-block",
+        "embedded-resource-block",
+        "table",
+        "table-row",
+        "table-cell",
+        "table-header-cell"
+      ]
+    },
+    "UnorderedList": {
+      "type": "object",
+      "properties": {
+        "nodeType": {
+          "type": "string",
+          "enum": [
+            "unordered-list"
+          ]
+        },
+        "data": {
+          "type": "object",
+          "properties": {}
+        },
+        "content": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ListItem"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "content",
+        "data",
+        "nodeType"
+      ]
     }
   },
   "$schema": "http://json-schema.org/draft-07/schema#"


### PR DESCRIPTION
updating schema for rich text type change in #616. this breaks tests as shown [here](https://app.circleci.com/pipelines/github/contentful/rich-text/1340/workflows/2585ea7a-f536-497e-9688-2c2ad92e701b/jobs/2797?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) which we fixed by updating the snapshots