### PR TITLE
fix: exporting schema function []

### DIFF
--- a/packages/rich-text-types/src/index.ts
+++ b/packages/rich-text-types/src/index.ts
@@ -11,3 +11,5 @@ export { EMPTY_DOCUMENT } from './emptyDocument';
 
 import * as helpers from './helpers';
 export { helpers };
+
+export { getSchemaWithNodeType } from './schemas';


### PR DESCRIPTION
Exporting from index so it's not imported from `@contentful/rich-text-types/dist/schema`