### PR TITLE
chore: fix pipeline by running husky locally

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 npx lint-staged


### PR DESCRIPTION
when we run yarn on the CI husky makes a change to the pre commit script to remove deprecated steps which causes the CI to fail. This PR applies the change so that we don't generate a change in the CI