### PR TITLE
feat(rich-text-links): improve getRichTextEntityLinks()

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,13 @@ each published separately to npm.
 
 ### Local Development
 
-Run `npm install` to install all necessary dependencies.
+Run `yarn install` to install all necessary dependencies.
 
-As a post-install step, all Lerna dependencies are [hoisted](https://github.com/lerna/lerna/blob/master/doc/hoist.md),
+`yarn build` ensures all Lerna dependencies are [hoisted](https://github.com/lerna/lerna/blob/master/doc/hoist.md),
 and hence internally reliant packages (e.g., `rich-text-html-renderer`, which
 depends upon `rich-text-types`) will resolve their modules via symlink. In other
-words, `npm install` will _both_ install external dependencies for each project,
-_and_ ensure packages that pull in other packages in this repository as
-dependencies are linked to the local version (rather than whatever the state
+words, `yarn build` ensure packages that pull in other packages in this repository
+as dependencies are linked to the local version (rather than whatever the state
 of those packages is on npm).
 
 Each package is written in [TypeScript](https://www.typescriptlang.org/) and

--- a/packages/rich-text-links/src/__test__/index.test.ts
+++ b/packages/rich-text-links/src/__test__/index.test.ts
@@ -491,18 +491,38 @@ describe('getRichTextEntityLinks', () => {
               },
               content: [],
             },
+            {
+              nodeType: INLINES.EMBEDDED_ENTRY,
+              data: {
+                target: {
+                  sys: {
+                    linkType: 'Entry',
+                    type: 'Link',
+                    id: 'baz',
+                  },
+                },
+              },
+              content: [],
+            },
           ],
         },
       ],
     };
 
     it('ignores all links of different types', () => {
-      expect(getRichTextEntityLinks(document, BLOCKS.EMBEDDED_ENTRY)).toEqual({
+      expect(
+        getRichTextEntityLinks(document, BLOCKS.EMBEDDED_ENTRY, INLINES.EMBEDDED_ENTRY),
+      ).toEqual({
         Entry: [
           {
             linkType: 'Entry',
             type: 'Link',
             id: 'foo',
+          },
+          {
+            linkType: 'Entry',
+            type: 'Link',
+            id: 'baz',
           },
         ],
         Asset: [],

--- a/packages/rich-text-links/src/index.ts
+++ b/packages/rich-text-links/src/index.ts
@@ -83,8 +83,10 @@ export function getRichTextEntityLinks(
   /**
    *  Node type. Only the entity links with given node type will be extracted.
    */
-  type?: string,
+  ...type: (BLOCKS | INLINES | string)[]
 ): EntityLinks {
+  const types = new Set(type);
+
   const entityLinks: EntityLinkMaps = {
     Entry: new Map(),
     Asset: new Map(),
@@ -92,7 +94,7 @@ export function getRichTextEntityLinks(
 
   // const content = (document && document.content) || ([] as Node[]);
   const addLink = ({ data, nodeType }: Node) => {
-    const hasRequestedNodeType = !type || nodeType === type;
+    const hasRequestedNodeType = !types.size || types.has(nodeType);
 
     if (hasRequestedNodeType && isLinkObject(data)) {
       entityLinks[data.target.sys.linkType].set(data.target.sys.id, data.target.sys);


### PR DESCRIPTION
WHAT?

Improve the implementation of `getRichTextEntityLinks()` so that instead of receiving a `type?: string`, it receives
`...type: (BLOCKS | INLINES | string)[]`.

WHY?

When specifying the `type` parameter. Most often than not, there's a need to filter on more than one `type`. Before this change, users were forced to call `getRichTextEntityLinks()` for each type. By accepting multiple values, a single invocation can get all the desired output more efficiently.

As for the `BLOCKS | INLINES` in addition to `string`, it's merely used for documentation reminding library users that they can specify the values in there, rather than explicit string values.

HOW?

`yarn build && yarn test && yarn lint && yarn prettier:check`