### PR TITLE
feat: add an option to strip empty trailing paragraphs [TOL-3193]

### DIFF
--- a/packages/rich-text-html-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-html-renderer/src/__test__/index.test.ts
@@ -467,3 +467,239 @@ describe('documentToHtmlString', () => {
     expect(documentToHtmlString(document, options)).toEqual(expected);
   });
 });
+
+describe('stripEmptyTrailingParagraph', () => {
+  it('strips empty trailing paragraph when enabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p>Hello world</p>');
+  });
+
+  it('does not strip empty trailing paragraph when disabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: false,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p>Hello world</p><p></p>');
+  });
+
+  it('does not strip empty trailing paragraph when it is the only child', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p></p>');
+  });
+
+  it('does not strip non-empty trailing paragraph', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Not empty',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p>Hello world</p><p>Not empty</p>');
+  });
+
+  it('does not strip trailing paragraph with multiple text nodes', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p>Hello world</p><p></p>');
+  });
+
+  it('does not strip trailing non-paragraph node', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.HEADING_1,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToHtmlString(document, options);
+    expect(result).toEqual('<p>Hello world</p><h1></h1>');
+  });
+});

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -110,10 +110,10 @@ export function documentToHtmlString(
   }
 
   // Strip empty trailing paragraph if enabled
-  const processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(
-    richTextDocument,
-    options.stripEmptyTrailingParagraph || false,
-  );
+  let processedDocument = richTextDocument;
+  if (options.stripEmptyTrailingParagraph) {
+    processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(richTextDocument);
+  }
 
   return nodeListToHtmlString(processedDocument.content, {
     renderNode: {

--- a/packages/rich-text-html-renderer/src/index.ts
+++ b/packages/rich-text-html-renderer/src/index.ts
@@ -92,6 +92,10 @@ export interface Options {
    * Keep line breaks and multiple spaces
    */
   preserveWhitespace?: boolean;
+  /**
+   * Strip empty trailing paragraph from the document
+   */
+  stripEmptyTrailingParagraph?: boolean;
 }
 
 /**
@@ -105,7 +109,13 @@ export function documentToHtmlString(
     return '';
   }
 
-  return nodeListToHtmlString(richTextDocument.content, {
+  // Strip empty trailing paragraph if enabled
+  const processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(
+    richTextDocument,
+    options.stripEmptyTrailingParagraph || false,
+  );
+
+  return nodeListToHtmlString(processedDocument.content, {
     renderNode: {
       ...defaultNodeRenderers,
       ...options.renderNode,

--- a/packages/rich-text-plain-text-renderer/src/__test__/index.test.ts
+++ b/packages/rich-text-plain-text-renderer/src/__test__/index.test.ts
@@ -181,3 +181,239 @@ describe('documentToPlainTextString', () => {
     });
   });
 });
+
+describe('stripEmptyTrailingParagraph', () => {
+  it('strips empty trailing paragraph when enabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('Hello world');
+  });
+
+  it('does not strip empty trailing paragraph when disabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: false,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('Hello world ');
+  });
+
+  it('does not strip empty trailing paragraph when it is the only child', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('');
+  });
+
+  it('does not strip non-empty trailing paragraph', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Not empty',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('Hello world Not empty');
+  });
+
+  it('does not strip trailing paragraph with multiple text nodes', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('Hello world ');
+  });
+
+  it('does not strip trailing non-paragraph node', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.HEADING_1,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToPlainTextString(document, ' ', options);
+    expect(result).toEqual('Hello world ');
+  });
+});

--- a/packages/rich-text-plain-text-renderer/src/index.ts
+++ b/packages/rich-text-plain-text-renderer/src/index.ts
@@ -31,11 +31,8 @@ export function documentToPlainTextString(
 
   // Strip empty trailing paragraph if enabled and rootNode is a Document
   let processedRootNode = rootNode;
-  if (rootNode.nodeType === BLOCKS.DOCUMENT) {
-    processedRootNode = helpers.stripEmptyTrailingParagraphFromDocument(
-      rootNode as Document,
-      options.stripEmptyTrailingParagraph || false,
-    );
+  if (rootNode.nodeType === BLOCKS.DOCUMENT && options.stripEmptyTrailingParagraph) {
+    processedRootNode = helpers.stripEmptyTrailingParagraphFromDocument(rootNode as Document);
   }
 
   /**

--- a/packages/rich-text-plain-text-renderer/src/index.ts
+++ b/packages/rich-text-plain-text-renderer/src/index.ts
@@ -1,4 +1,11 @@
-import { Block, Inline, Node, helpers } from '@contentful/rich-text-types';
+import { Block, Inline, Node, helpers, BLOCKS, Document } from '@contentful/rich-text-types';
+
+export interface Options {
+  /**
+   * Strip empty trailing paragraph from the document
+   */
+  stripEmptyTrailingParagraph?: boolean;
+}
 
 /**
  * Returns the text value of a rich text document.
@@ -9,6 +16,7 @@ import { Block, Inline, Node, helpers } from '@contentful/rich-text-types';
 export function documentToPlainTextString(
   rootNode: Block | Inline,
   blockDivisor: string = ' ',
+  options: Options = {},
 ): string {
   if (!rootNode || !rootNode.content || !Array.isArray(rootNode.content)) {
     /**
@@ -19,6 +27,15 @@ export function documentToPlainTextString(
      * should never lack a Node[] `content` property.
      */
     return '';
+  }
+
+  // Strip empty trailing paragraph if enabled and rootNode is a Document
+  let processedRootNode = rootNode;
+  if (rootNode.nodeType === BLOCKS.DOCUMENT) {
+    processedRootNode = helpers.stripEmptyTrailingParagraphFromDocument(
+      rootNode as Document,
+      options.stripEmptyTrailingParagraph || false,
+    );
   }
 
   /**
@@ -84,21 +101,24 @@ export function documentToPlainTextString(
    * 'Yet another list item' - the non-semantic HR between the two nodes should
    * not denote an additional space.
    */
-  return (rootNode as Block).content.reduce((acc: string, node: Node, i: number): string => {
-    let nodeTextValue: string;
+  return (processedRootNode as Block).content.reduce(
+    (acc: string, node: Node, i: number): string => {
+      let nodeTextValue: string;
 
-    if (helpers.isText(node)) {
-      nodeTextValue = node.value;
-    } else if (helpers.isBlock(node) || helpers.isInline(node)) {
-      nodeTextValue = documentToPlainTextString(node, blockDivisor);
-      if (!nodeTextValue.length) {
-        return acc;
+      if (helpers.isText(node)) {
+        nodeTextValue = node.value;
+      } else if (helpers.isBlock(node) || helpers.isInline(node)) {
+        nodeTextValue = documentToPlainTextString(node, blockDivisor, options);
+        if (!nodeTextValue.length) {
+          return acc;
+        }
       }
-    }
 
-    const nextNode = rootNode.content[i + 1];
-    const isNextNodeBlock = nextNode && helpers.isBlock(nextNode);
-    const divisor = isNextNodeBlock ? blockDivisor : '';
-    return acc + nodeTextValue + divisor;
-  }, '');
+      const nextNode = processedRootNode.content[i + 1];
+      const isNextNodeBlock = nextNode && helpers.isBlock(nextNode);
+      const divisor = isNextNodeBlock ? blockDivisor : '';
+      return acc + nodeTextValue + divisor;
+    },
+    '',
+  );
 }

--- a/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
+++ b/packages/rich-text-react-renderer/src/__test__/__snapshots__/index.test.tsx.snap
@@ -511,3 +511,64 @@ exports[`preserveWhitespace preserves spaces between words 1`] = `
   </p>,
 ]
 `;
+
+exports[`stripEmptyTrailingParagraph does not strip empty trailing paragraph when disabled 1`] = `
+[
+  <p>
+    Hello world
+  </p>,
+  <p>
+    
+  </p>,
+]
+`;
+
+exports[`stripEmptyTrailingParagraph does not strip empty trailing paragraph when it is the only child 1`] = `
+[
+  <p>
+    
+  </p>,
+]
+`;
+
+exports[`stripEmptyTrailingParagraph does not strip non-empty trailing paragraph 1`] = `
+[
+  <p>
+    Hello world
+  </p>,
+  <p>
+    Not empty
+  </p>,
+]
+`;
+
+exports[`stripEmptyTrailingParagraph does not strip trailing non-paragraph node 1`] = `
+[
+  <p>
+    Hello world
+  </p>,
+  <h1>
+    
+  </h1>,
+]
+`;
+
+exports[`stripEmptyTrailingParagraph does not strip trailing paragraph with multiple text nodes 1`] = `
+[
+  <p>
+    Hello world
+  </p>,
+  <p>
+    
+    
+  </p>,
+]
+`;
+
+exports[`stripEmptyTrailingParagraph strips empty trailing paragraph when enabled 1`] = `
+[
+  <p>
+    Hello world
+  </p>,
+]
+`;

--- a/packages/rich-text-react-renderer/src/__test__/index.test.tsx
+++ b/packages/rich-text-react-renderer/src/__test__/index.test.tsx
@@ -487,3 +487,239 @@ describe('preserveWhitespace', () => {
     expect(documentToReactComponents(document, options)).toMatchSnapshot();
   });
 });
+
+describe('stripEmptyTrailingParagraph', () => {
+  it('strips empty trailing paragraph when enabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('does not strip empty trailing paragraph when disabled', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: false,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('does not strip empty trailing paragraph when it is the only child', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('does not strip non-empty trailing paragraph', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Not empty',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('does not strip trailing paragraph with multiple text nodes', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+
+  it('does not strip trailing non-paragraph node', () => {
+    const document: Document = {
+      nodeType: BLOCKS.DOCUMENT,
+      data: {},
+      content: [
+        {
+          nodeType: BLOCKS.PARAGRAPH,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: 'Hello world',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+        {
+          nodeType: BLOCKS.HEADING_1,
+          data: {},
+          content: [
+            {
+              nodeType: 'text',
+              value: '',
+              marks: [],
+              data: {},
+            },
+          ],
+        },
+      ],
+    };
+
+    const options: Options = {
+      stripEmptyTrailingParagraph: true,
+    };
+
+    const result = documentToReactComponents(document, options);
+    expect(result).toMatchSnapshot();
+  });
+});

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -1,6 +1,15 @@
 import React, { ReactNode } from 'react';
 
-import { Block, BLOCKS, Document, Inline, INLINES, MARKS, Text } from '@contentful/rich-text-types';
+import {
+  Block,
+  BLOCKS,
+  Document,
+  Inline,
+  INLINES,
+  MARKS,
+  Text,
+  helpers,
+} from '@contentful/rich-text-types';
 
 import { nodeToReactComponent } from './util/nodeListToReactComponents';
 
@@ -99,6 +108,10 @@ export interface Options {
    * Keep line breaks and multiple spaces
    */
   preserveWhitespace?: boolean;
+  /**
+   * Strip empty trailing paragraph from the document
+   */
+  stripEmptyTrailingParagraph?: boolean;
 }
 
 /**
@@ -112,7 +125,13 @@ export function documentToReactComponents(
     return null;
   }
 
-  return nodeToReactComponent(richTextDocument, {
+  // Strip empty trailing paragraph if enabled
+  const processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(
+    richTextDocument,
+    options.stripEmptyTrailingParagraph || false,
+  );
+
+  return nodeToReactComponent(processedDocument, {
     renderNode: {
       ...defaultNodeRenderers,
       ...options.renderNode,

--- a/packages/rich-text-react-renderer/src/index.tsx
+++ b/packages/rich-text-react-renderer/src/index.tsx
@@ -126,10 +126,10 @@ export function documentToReactComponents(
   }
 
   // Strip empty trailing paragraph if enabled
-  const processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(
-    richTextDocument,
-    options.stripEmptyTrailingParagraph || false,
-  );
+  let processedDocument = richTextDocument;
+  if (options.stripEmptyTrailingParagraph) {
+    processedDocument = helpers.stripEmptyTrailingParagraphFromDocument(richTextDocument);
+  }
 
   return nodeToReactComponent(processedDocument, {
     renderNode: {

--- a/packages/rich-text-types/src/__test__/helpers.test.ts
+++ b/packages/rich-text-types/src/__test__/helpers.test.ts
@@ -1,0 +1,212 @@
+import { BLOCKS } from '../blocks';
+import { helpers } from '../index';
+import { Document, Mark } from '../types';
+
+describe('helpers', () => {
+  describe('isEmptyParagraph', () => {
+    it('returns true for empty paragraph', () => {
+      const node = {
+        nodeType: BLOCKS.PARAGRAPH,
+        data: {},
+        content: [
+          {
+            nodeType: 'text' as const,
+            value: '',
+            marks: [] as Mark[],
+            data: {},
+          },
+        ],
+      };
+      expect(helpers.isEmptyParagraph(node)).toBe(true);
+    });
+
+    it('returns false for non-empty paragraph', () => {
+      const node = {
+        nodeType: BLOCKS.PARAGRAPH,
+        data: {},
+        content: [
+          {
+            nodeType: 'text' as const,
+            value: 'Hello world',
+            marks: [] as Mark[],
+            data: {},
+          },
+        ],
+      };
+      expect(helpers.isEmptyParagraph(node)).toBe(false);
+    });
+
+    it('returns false for paragraph with multiple text nodes', () => {
+      const node = {
+        nodeType: BLOCKS.PARAGRAPH,
+        data: {},
+        content: [
+          {
+            nodeType: 'text' as const,
+            value: '',
+            marks: [] as Mark[],
+            data: {},
+          },
+          {
+            nodeType: 'text' as const,
+            value: '',
+            marks: [] as Mark[],
+            data: {},
+          },
+        ],
+      };
+      expect(helpers.isEmptyParagraph(node)).toBe(false);
+    });
+
+    it('returns false for non-paragraph node', () => {
+      const node = {
+        nodeType: BLOCKS.HEADING_1,
+        data: {},
+        content: [
+          {
+            nodeType: 'text' as const,
+            value: '',
+            marks: [] as Mark[],
+            data: {},
+          },
+        ],
+      };
+      expect(helpers.isEmptyParagraph(node)).toBe(false);
+    });
+  });
+
+  describe('stripEmptyTrailingParagraphFromDocument', () => {
+    it('strips empty trailing paragraph when enabled', () => {
+      const document: Document = {
+        nodeType: BLOCKS.DOCUMENT,
+        data: {},
+        content: [
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: 'Hello world',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: '',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].nodeType).toBe(BLOCKS.PARAGRAPH);
+    });
+
+    it('does not strip empty trailing paragraph when disabled', () => {
+      const document: Document = {
+        nodeType: BLOCKS.DOCUMENT,
+        data: {},
+        content: [
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: 'Hello world',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: '',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, false);
+      expect(result.content).toHaveLength(2);
+    });
+
+    it('does not strip empty trailing paragraph when it is the only child', () => {
+      const document: Document = {
+        nodeType: BLOCKS.DOCUMENT,
+        data: {},
+        content: [
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: '',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      expect(result.content).toHaveLength(1);
+    });
+
+    it('does not strip non-empty trailing paragraph', () => {
+      const document: Document = {
+        nodeType: BLOCKS.DOCUMENT,
+        data: {},
+        content: [
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: 'Hello world',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+          {
+            nodeType: BLOCKS.PARAGRAPH,
+            data: {},
+            content: [
+              {
+                nodeType: 'text' as const,
+                value: 'Not empty',
+                marks: [] as Mark[],
+                data: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      expect(result.content).toHaveLength(2);
+    });
+  });
+});

--- a/packages/rich-text-types/src/__test__/helpers.test.ts
+++ b/packages/rich-text-types/src/__test__/helpers.test.ts
@@ -76,7 +76,7 @@ describe('helpers', () => {
   });
 
   describe('stripEmptyTrailingParagraphFromDocument', () => {
-    it('strips empty trailing paragraph when enabled', () => {
+    it('strips empty trailing paragraph', () => {
       const document: Document = {
         nodeType: BLOCKS.DOCUMENT,
         data: {},
@@ -108,45 +108,9 @@ describe('helpers', () => {
         ],
       };
 
-      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document);
       expect(result.content).toHaveLength(1);
       expect(result.content[0].nodeType).toBe(BLOCKS.PARAGRAPH);
-    });
-
-    it('does not strip empty trailing paragraph when disabled', () => {
-      const document: Document = {
-        nodeType: BLOCKS.DOCUMENT,
-        data: {},
-        content: [
-          {
-            nodeType: BLOCKS.PARAGRAPH,
-            data: {},
-            content: [
-              {
-                nodeType: 'text' as const,
-                value: 'Hello world',
-                marks: [] as Mark[],
-                data: {},
-              },
-            ],
-          },
-          {
-            nodeType: BLOCKS.PARAGRAPH,
-            data: {},
-            content: [
-              {
-                nodeType: 'text' as const,
-                value: '',
-                marks: [] as Mark[],
-                data: {},
-              },
-            ],
-          },
-        ],
-      };
-
-      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, false);
-      expect(result.content).toHaveLength(2);
     });
 
     it('does not strip empty trailing paragraph when it is the only child', () => {
@@ -169,7 +133,7 @@ describe('helpers', () => {
         ],
       };
 
-      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document);
       expect(result.content).toHaveLength(1);
     });
 
@@ -205,7 +169,7 @@ describe('helpers', () => {
         ],
       };
 
-      const result = helpers.stripEmptyTrailingParagraphFromDocument(document, true);
+      const result = helpers.stripEmptyTrailingParagraphFromDocument(document);
       expect(result.content).toHaveLength(2);
     });
   });

--- a/packages/rich-text-types/src/helpers.ts
+++ b/packages/rich-text-types/src/helpers.ts
@@ -67,16 +67,12 @@ const MIN_NODES_FOR_STRIPPING = 2;
 /**
  * Strips empty trailing paragraph from a document if enabled
  * @param document - The rich text document to process
- * @param enabled - Whether to enable empty trailing paragraph stripping
  * @returns A new document with the empty trailing paragraph removed (if conditions are met)
  * @example
- * const processedDoc = stripEmptyTrailingParagraphFromDocument(document, true);
+ * const processedDoc = stripEmptyTrailingParagraphFromDocument(document);
  */
-export function stripEmptyTrailingParagraphFromDocument(
-  document: CDocument,
-  enabled: boolean,
-): CDocument {
-  if (!enabled || !isValidDocument(document) || document.content.length < MIN_NODES_FOR_STRIPPING) {
+export function stripEmptyTrailingParagraphFromDocument(document: CDocument): CDocument {
+  if (!isValidDocument(document) || document.content.length < MIN_NODES_FOR_STRIPPING) {
     return document;
   }
 

--- a/packages/rich-text-types/src/helpers.ts
+++ b/packages/rich-text-types/src/helpers.ts
@@ -1,6 +1,6 @@
 import { BLOCKS } from './blocks';
 import { INLINES } from './inlines';
-import { Block, Inline, Node, Text } from './types';
+import { Block, Inline, Node, Text, Document } from './types';
 
 /**
  * Tiny replacement for Object.values(object).includes(key) to
@@ -35,4 +35,64 @@ export function isBlock(node: Node): node is Block {
  */
 export function isText(node: Node): node is Text {
   return node.nodeType === 'text';
+}
+
+/**
+ * Checks if a paragraph is empty (has only one child and that child is an empty string text node)
+ */
+export function isEmptyParagraph(node: Block): boolean {
+  if (node.nodeType !== BLOCKS.PARAGRAPH) {
+    return false;
+  }
+
+  if (node.content.length !== 1) {
+    return false;
+  }
+
+  const textNode = node.content[0];
+  return textNode.nodeType === 'text' && (textNode as Text).value === '';
+}
+
+function isValidDocument(document: unknown): document is Document {
+  return (
+    document != null &&
+    typeof document === 'object' &&
+    'content' in document &&
+    Array.isArray((document as Document).content)
+  );
+}
+
+const MIN_CONTENT_LENGTH_FOR_STRIPPING = 2;
+
+/**
+ * Strips empty trailing paragraph from a document if enabled
+ * @param document - The rich text document to process
+ * @param enabled - Whether to enable empty trailing paragraph stripping
+ * @returns A new document with the empty trailing paragraph removed (if conditions are met)
+ * @example
+ * const processedDoc = stripEmptyTrailingParagraphFromDocument(document, true);
+ */
+export function stripEmptyTrailingParagraphFromDocument(
+  document: Document,
+  enabled: boolean,
+): Document {
+  if (
+    !enabled ||
+    !isValidDocument(document) ||
+    document.content.length < MIN_CONTENT_LENGTH_FOR_STRIPPING
+  ) {
+    return document;
+  }
+
+  const lastNode = document.content[document.content.length - 1];
+
+  // Check if the last node is an empty paragraph
+  if (isEmptyParagraph(lastNode)) {
+    return {
+      ...document,
+      content: document.content.slice(0, -1),
+    };
+  }
+
+  return document;
 }

--- a/packages/rich-text-types/src/helpers.ts
+++ b/packages/rich-text-types/src/helpers.ts
@@ -1,6 +1,6 @@
 import { BLOCKS } from './blocks';
 import { INLINES } from './inlines';
-import { Block, Inline, Node, Text, Document } from './types';
+import { Block, Inline, Node, Text, Document as CDocument } from './types';
 
 /**
  * Tiny replacement for Object.values(object).includes(key) to
@@ -53,16 +53,16 @@ export function isEmptyParagraph(node: Block): boolean {
   return textNode.nodeType === 'text' && (textNode as Text).value === '';
 }
 
-function isValidDocument(document: unknown): document is Document {
+function isValidDocument(document: unknown): document is CDocument {
   return (
     document != null &&
     typeof document === 'object' &&
     'content' in document &&
-    Array.isArray((document as Document).content)
+    Array.isArray((document as CDocument).content)
   );
 }
 
-const MIN_CONTENT_LENGTH_FOR_STRIPPING = 2;
+const MIN_NODES_FOR_STRIPPING = 2;
 
 /**
  * Strips empty trailing paragraph from a document if enabled
@@ -73,14 +73,10 @@ const MIN_CONTENT_LENGTH_FOR_STRIPPING = 2;
  * const processedDoc = stripEmptyTrailingParagraphFromDocument(document, true);
  */
 export function stripEmptyTrailingParagraphFromDocument(
-  document: Document,
+  document: CDocument,
   enabled: boolean,
-): Document {
-  if (
-    !enabled ||
-    !isValidDocument(document) ||
-    document.content.length < MIN_CONTENT_LENGTH_FOR_STRIPPING
-  ) {
+): CDocument {
+  if (!enabled || !isValidDocument(document) || document.content.length < MIN_NODES_FOR_STRIPPING) {
     return document;
   }
 


### PR DESCRIPTION
allow renderers to pass configurable stripEmptyTrailingParagraph option in order to skip trailing paragraph