### PR TITLE
fix: resolve build correctly []

### DIFF
--- a/packages/rich-text-react-renderer/tsconfig.json
+++ b/packages/rich-text-react-renderer/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "declarationDir": "dist/types",
-    "outDir": "dist/lib",
+    "outDir": "dist",
     "typeRoots": ["../../node_modules/@types", "node_modules/@types", "src/typings"],
     "jsx": "react"
   },


### PR DESCRIPTION
our tsconfig had it's output set to dist/lib which conflicted with rollup's output dir of dist and broke local imports. This should now be fixed