### PR TITLE
fix(build): resolve ESM import failures in rich-text-types [TOL-3435]

### DIFF
--- a/packages/rich-text-types/package.json
+++ b/packages/rich-text-types/package.json
@@ -2,12 +2,12 @@
   "name": "@contentful/rich-text-types",
   "version": "17.2.3",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.mjs",
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "import": "./dist/esm/index.js",
+      "import": "./dist/esm/index.mjs",
       "require": "./dist/cjs/index.js",
       "default": "./dist/cjs/index.js"
     },
@@ -30,11 +30,12 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "npm run build:types && npm run build:cjs && npm run build:esm",
+    "build": "npm run build:types && npm run build:cjs && npm run build:esm && npm run fix-esm-imports",
     "build:types": "tsc --outDir dist/types --emitDeclarationOnly",
-    "build:cjs": "swc src --strip-leading-paths --config-file ../../.swcrc -d dist/cjs",
-    "build:esm": "swc src --strip-leading-paths --config-file ../../.swcrc -d dist/esm -C module.type=es6",
-    "start": "tsc && swc src --strip-leading-paths --config-file ../../.swcrc -d dist/esm -C module.type=es6 -w",
+    "build:cjs": "swc src --strip-leading-paths --config-file ../../.swcrc -d dist/cjs -C module.type=commonjs",
+    "build:esm": "swc src --strip-leading-paths --config-file ../../.swcrc -d dist/esm --out-file-extension mjs -C module.type=es6 -C module.resolveFully=true -C module.outFileExtension=mjs",
+    "fix-esm-imports": "node ./scripts/fix-esm-import-extensions.mjs",
+    "start": "tsc && swc src --strip-leading-paths --config-file ../../.swcrc -d dist/esm --out-file-extension mjs -C module.type=es6 -C module.resolveFully=true -C module.outFileExtension=mjs -w",
     "test": "jest"
   },
   "dependencies": {

--- a/packages/rich-text-types/scripts/fix-esm-import-extensions.mjs
+++ b/packages/rich-text-types/scripts/fix-esm-import-extensions.mjs
@@ -1,0 +1,37 @@
+// Rewrite relative `*.js` specifiers to `*.mjs` across built ESM files
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, extname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const esmDir = join(here, '..', 'dist', 'esm');
+
+// Recursively walk all .mjs files under `dir`
+async function* walk(dir) {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(p);
+    else if (extname(p) === '.mjs') yield p;
+  }
+}
+
+const REWRITES = [
+  // import ... from './x.js'
+  [/(from\s+['"])(\.{1,2}\/[^'"]+)\.js(['"])/g, '$1$2.mjs$3'],
+  // export ... from './x.js'
+  [/(export\s+(?:\*|{[\s\S]*?})\s+from\s+['"])(\.{1,2}\/[^'"]+)\.js(['"])/g, '$1$2.mjs$3'],
+  // import('./x.js')
+  [/(import\(\s*['"])(\.{1,2}\/[^'"]+)\.js(['"]\s*\))/g, '$1$2.mjs$3'],
+];
+
+function rewrite(code) {
+  return REWRITES.reduce((s, [re, replacement]) => s.replace(re, replacement), code);
+}
+
+for await (const file of walk(esmDir)) {
+  const original = await readFile(file, 'utf8');
+  const updated = rewrite(original);
+  if (updated !== original) {
+    await writeFile(file, updated, 'utf8');
+  }
+}


### PR DESCRIPTION
- `module` and `exports.import` now point at `dist/esm/index.mjs`, which guarantees ESM without syntax detection
- SWC emits `.mjs` files
- The script rewrites relative `from './x.js'`, `export … from './x.js'`, and `import('./x.js')` to `.mjs`

Fixes https://github.com/contentful/rich-text/issues/931

I tested this approach in test project in all three scenario's:

<img width="835" height="313" alt="Screenshot 2025-09-23 at 11 05 32" src="https://github.com/user-attachments/assets/caf2cbfe-1046-4786-b017-800808282a50" />
