### PR TITLE
fix(ci): force full rebuild of all packages on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run: |
           echo "@contentful:registry=https://npm.pkg.github.com" >> ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=${GITHUB_PACKAGES_WRITE_TOKEN}" >> ~/.npmrc
-      - run: pnpm nx run-many -t build
+      - run: pnpm nx run-many --all -t build --skip-nx-cache
       - run: pnpm lerna version --no-private --conventional-commits --create-release github --yes
       - run: pnpm lerna publish from-git --yes
 


### PR DESCRIPTION
## Summary

- Adds `--all` and `--skip-nx-cache` to the `nx run-many` build command in the `release` job
- The `lint-and-test` job only builds *affected* packages via `nx affected`, so the persisted workspace may be missing `dist/` dirs for unaffected packages
- Without `--skip-nx-cache`, Nx considers those packages cache-hit and skips rebuilding them — leaving `dist/` absent at publish time

fixes https://github.com/contentful/rich-text/issues/1074
