### PR TITLE
test: verify CI workflows with an actual affected package

### DIFF
--- a/packages/rich-text-html-renderer/src/escapeHtml.ts
+++ b/packages/rich-text-html-renderer/src/escapeHtml.ts
@@ -1,3 +1,4 @@
+// CI verification: confirms nx affected picks up a real package change.
 const escapeRegExp = /["'&<>]/g;
 
 const escapeMap: Record<string, string> = {


### PR DESCRIPTION
Throwaway PR to verify build.yaml/check.yaml behave correctly when nx affected finds a real affected project (PR #1106 only touched CI config, so nx affected found zero projects and never exercised the actual build/cache/lint/test path with real dist output).

Not for merging — will be closed after verification.