### PR TITLE
chore(release): version bump for slatejs-adapter and react-renderer to 16.2.2

### DIFF
--- a/packages/contentful-slatejs-adapter/CHANGELOG.md
+++ b/packages/contentful-slatejs-adapter/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [16.2.2](https://github.com/contentful/rich-text/compare/@contentful/contentful-slatejs-adapter@16.2.1...@contentful/contentful-slatejs-adapter@16.2.2) (2026-07-22)
+
+**Note:** Version bump only for package @contentful/contentful-slatejs-adapter
+
 ## [16.2.1](https://github.com/contentful/rich-text/compare/@contentful/contentful-slatejs-adapter@16.2.0...@contentful/contentful-slatejs-adapter@16.2.1) (2026-04-09)
 
 **Note:** Version bump only for package @contentful/contentful-slatejs-adapter

--- a/packages/contentful-slatejs-adapter/package.json
+++ b/packages/contentful-slatejs-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/contentful-slatejs-adapter",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "description": "",
   "keywords": [],
   "main": "dist/contentful-slatejs-adapter.es5.js",

--- a/packages/rich-text-react-renderer/CHANGELOG.md
+++ b/packages/rich-text-react-renderer/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [16.2.2](https://github.com/contentful/rich-text/compare/@contentful/rich-text-react-renderer@16.2.1...@contentful/rich-text-react-renderer@16.2.2) (2026-07-22)
+
+**Note:** Version bump only for package @contentful/rich-text-react-renderer
+
 ## [16.2.1](https://github.com/contentful/rich-text/compare/@contentful/rich-text-react-renderer@16.2.0...@contentful/rich-text-react-renderer@16.2.1) (2026-04-09)
 
 ### Bug Fixes

--- a/packages/rich-text-react-renderer/package.json
+++ b/packages/rich-text-react-renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contentful/rich-text-react-renderer",
-  "version": "16.2.1",
+  "version": "16.2.2",
   "main": "dist/rich-text-react-renderer.es5.js",
   "module": "dist/rich-text-react-renderer.esm.js",
   "typings": "dist/types/index.d.ts",


### PR DESCRIPTION
## Summary

The release automation user was missing a permission required to push the version-bump commit, which caused the `Release` GitHub Actions job to fail on every merge to master since 2026-07-21 (see runs [29828610559](https://github.com/contentful/rich-text/actions/runs/29828610559), [29829408246](https://github.com/contentful/rich-text/actions/runs/29829408246), [29890545022](https://github.com/contentful/rich-text/actions/runs/29890545022), [29901228810](https://github.com/contentful/rich-text/actions/runs/29901228810)). The permission has since been fixed, but the version bumps that failed to commit still need to land manually.

`lerna version` (dry run, no push) confirms the pending bump is:

- `@contentful/contentful-slatejs-adapter`: `16.2.1` → `16.2.2`
- `@contentful/rich-text-react-renderer`: `16.2.1` → `16.2.2`

This PR applies that version bump and changelog entries by hand (`rich-text-html-renderer` and `rich-text-from-markdown` already released successfully at `16.2.2`/`17.2.3`, so they're untouched here).

## Test plan
- [x] Confirmed via `git ls-remote --tags` and CI logs that `contentful-slatejs-adapter` and `rich-text-react-renderer` are the only packages with a pending, unreleased version bump
- [x] Ran `lerna version --no-private --conventional-commits --yes --no-push --allow-branch <branch>` locally to compute the exact bump lerna would have applied
- [x] Verified `package.json` and `CHANGELOG.md` diffs match lerna's computed output