### PR TITLE
fix(ci): remove invalid --yes flag from nx release subcommands

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,9 @@ jobs:
       - name: Version and tag packages
         env:
           GITHUB_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
-        run: pnpm nx release version --yes
+        run: pnpm nx release version
 
       - name: Publish packages
         env:
           GH_TOKEN: ${{ steps.vault.outputs.GITHUB_PACKAGES_WRITE_TOKEN }}
-        run: pnpm nx release publish --yes
+        run: pnpm nx release publish


### PR DESCRIPTION
## Summary
- The release job's version/publish steps call `nx release version --yes` and `nx release publish --yes`, but `--yes`/`-y` only exists on the combined `nx release` command (it answers the interactive publish-confirmation prompt) — not on the split `version`/`publish` subcommands, which have no such prompt.
- CI has been failing with `Unknown argument: yes` on the "Version and tag packages" step since the lerna → nx release migration (#1115).
- Fix: drop `--yes` from both invocations.