### PR TITLE
fix: restrict GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,9 @@ name: Build
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -3,6 +3,9 @@ name: Check
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['**']
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}


### PR DESCRIPTION
## Summary

- set explicit read-only token permissions on the reusable build and check workflows
- set read-only defaults on the CI caller workflow
- preserve the release job’s explicit `contents: write` and `id-token: write` permissions
- resolve all four CodeQL missing-workflow-permissions findings

## Validation

- parsed permission contract assertions for all three workflows
- actionlint for `build.yaml`, `check.yaml`, and `ci.yml`
- Prettier check
- `git diff --check`

Jira:
- https://contentful.atlassian.net/browse/ACT-4453
- https://contentful.atlassian.net/browse/ACT-4454
- https://contentful.atlassian.net/browse/ACT-4455
- https://contentful.atlassian.net/browse/ACT-4456